### PR TITLE
Allow custom CSS classes

### DIFF
--- a/app/presenters/hotwire_combobox/component.rb
+++ b/app/presenters/hotwire_combobox/component.rb
@@ -22,13 +22,15 @@ class HotwireCombobox::Component
       view, autocomplete, id, name, value, form, async_src,
       name_when_new, open, data, mobile_at, options, dialog_label
 
+    @custom_classes = rest.select { |key, _| key.to_s.end_with?('_class') }.with_indifferent_access
+    rest.reject! { |key, _| key.to_s.end_with?('_class') }
     @combobox_attrs = input.reverse_merge(rest).with_indifferent_access
     @association_name = association_name || infer_association_name
   end
 
   def fieldset_attrs
     {
-      class: "hw-combobox",
+      class: css_classes("fieldset"),
       data: fieldset_data
     }
   end
@@ -50,7 +52,7 @@ class HotwireCombobox::Component
     {
       id: input_id,
       role: :combobox,
-      class: "hw-combobox__input",
+      class: css_classes("input"),
       type: input_type,
       data: input_data,
       aria: input_aria
@@ -60,7 +62,7 @@ class HotwireCombobox::Component
 
   def handle_attrs
     {
-      class: "hw-combobox__handle",
+      class: css_classes("handle"),
       data: handle_data
     }
   end
@@ -70,7 +72,7 @@ class HotwireCombobox::Component
     {
       id: listbox_id,
       role: :listbox,
-      class: "hw-combobox__listbox",
+      class: css_classes("listbox"),
       hidden: "",
       data: listbox_data
     }
@@ -84,13 +86,13 @@ class HotwireCombobox::Component
 
   def dialog_wrapper_attrs
     {
-      class: "hw-combobox__dialog__wrapper"
+      class: css_classes("dialog__wrapper")
     }
   end
 
   def dialog_attrs
     {
-      class: "hw-combobox__dialog",
+      class: css_classes("dialog"),
       role: :dialog,
       data: dialog_data
     }
@@ -98,7 +100,7 @@ class HotwireCombobox::Component
 
   def dialog_label_attrs
     {
-      class: "hw-combobox__dialog__label",
+      class: css_classes("dialog__label"),
       for: dialog_input_id
     }
   end
@@ -107,7 +109,7 @@ class HotwireCombobox::Component
     {
       id: dialog_input_id,
       role: :combobox,
-      class: "hw-combobox__dialog__input",
+      class: css_classes("dialog__input"),
       autofocus: "",
       type: input_type,
       data: dialog_input_data,
@@ -118,7 +120,7 @@ class HotwireCombobox::Component
   def dialog_listbox_attrs
     {
       id: dialog_listbox_id,
-      class: "hw-combobox__dialog__listbox",
+      class: css_classes("dialog__listbox"),
       role: :listbox,
       data: dialog_listbox_data
     }
@@ -298,5 +300,23 @@ class HotwireCombobox::Component
 
     def dialog_focus_trap_data
       { hw_combobox_target: "dialogFocusTrap" }
+    end
+
+
+    def css_classes(element)
+      [
+        css_base_class(element),
+        css_custom_class(element)
+      ].compact.join(" ")
+    end
+
+    def css_base_class(element)
+      return "hw-combobox" if element == "fieldset"
+
+      "hw-combobox__#{element}"
+    end
+
+    def css_custom_class(element)
+      @custom_classes["#{element.gsub('-', '_').gsub('__', '_')}_class"]
     end
 end

--- a/test/helpers/hotwire_combobox/helper_test.rb
+++ b/test/helpers/hotwire_combobox/helper_test.rb
@@ -61,6 +61,28 @@ class HotwireCombobox::HelperTest < ApplicationViewTestCase
       "aria-haspopup": "listbox", "aria-autocomplete": "both"
   end
 
+  test "passing custom classes (per element) adds them to the built-in classes" do
+    options = hw_combobox_options [
+      { value: :baz, display: :Baz },
+      { value: :quux, display: :Quux }
+    ]
+    tag = combobox_tag :foo, options, value: :baz,
+                       fieldset_class: 'CustomFieldSet', input_class: 'CustomInput', handle_class: 'CustomHandle',
+                       listbox_class: 'CustomListBox',
+                       dialog_class: 'CustomDialog', dialog_wrapper_class: 'CustomDialogWrapper',
+                       dialog_input_class: 'CustomDialogInput', dialog_label_class: 'CustomDialogLabel'
+
+    refute_includes tag, 'input_class="CustomInput"'
+    assert_includes tag, 'class="hw-combobox CustomFieldSet"'
+    assert_includes tag, 'class="hw-combobox__input CustomInput"'
+    assert_includes tag, 'class="hw-combobox__handle CustomHandle"'
+    assert_includes tag, 'class="hw-combobox__listbox CustomListBox"'
+    assert_includes tag, 'class="hw-combobox__dialog CustomDialog"'
+    assert_includes tag, 'class="hw-combobox__dialog__wrapper CustomDialogWrapper"'
+    assert_includes tag, 'class="hw-combobox__dialog__input CustomDialogInput"'
+    assert_includes tag, 'class="hw-combobox__dialog__label CustomDialogLabel"'
+  end
+
   test "hw_combobox_options instantiates an array of `HotwireCombobox::Listbox::Option`s" do
     options = hw_combobox_options [
       { value: :foo, display: :bar },


### PR DESCRIPTION
Hi Jose,

When you added default CSS styling (among other refactoring between 0.1.11 and 0.1.32), I lost the ability to easily apply an existing design library to these elements. I don't know if that was an intentional choice or not, and so I realize you may not be interested in adopting this change.

Here's my point of view on this as I consider my options for an internal app that will make heavy use of comboboxes:

Re-defining the default classnames might work okay when the Rails app has one universal style, although it requires value-less work by the app's developers/maintainers when the Rails app is using a component library like Bootstrap or Daisy UI. (As an app maintainer currently responsible for 3 Rails apps that are 10-15 years old, I'm worried about paying that integration cost multiple times if this gem's default CSS class names change over time.)

My proposed flexibility here also allows simple customization within an app. For example, the main app that I am currently evaluating for use with this gem has a style guide with patterns where filtering forms have a different UX/UI than create/update forms. (Filtering forms and pagination link sets use Daisy UI's "info" variant while data modification forms use the default black/dark-gray variants.)

_Note: I did not see a clean way to add a custom option class since it is hardwired in `Option` and so I have not attempted allowing either that customization or customization on the selected option variant (defined separately in `Component` and close to these customizations). This might point to a further re-structuring if you're comfortable with integrating this kind of feature._