### PR TITLE
Second attempt to select option fails for new options setup.

### DIFF
--- a/app/assets/javascripts/models/combobox/options.js
+++ b/app/assets/javascripts/models/combobox/options.js
@@ -8,11 +8,19 @@ Combobox.Options = Base => class extends Base {
   }
 
   _isValidNewOption(query, { ignoreAutocomplete = false } = {}) {
+    if (!this._allowNew || this._hasSameValueInOptions) {
+      return false
+    }
+
     const typedValue = this._actingCombobox.value
     const autocompletedValue = this._visibleOptionElements[0]?.getAttribute(this.autocompletableAttributeValue)
     const insufficientAutocomplete = !autocompletedValue || !startsWith(autocompletedValue, typedValue)
 
-    return query.length > 0 && this._allowNew && (ignoreAutocomplete || insufficientAutocomplete)
+    return query.length > 0 && (ignoreAutocomplete || insufficientAutocomplete)
+  }
+
+  get _hasSameValueInOptions() {
+    return this._visibleOptionElements.some((el) => el.innerText === this._actingCombobox.value)
   }
 
   get _allowNew() {

--- a/test/system/hotwire_combobox_test.rb
+++ b/test/system/hotwire_combobox_test.rb
@@ -258,6 +258,26 @@ class HotwireComboboxTest < ApplicationSystemTestCase
     assert_selector "input[role=combobox]"
   end
 
+  test "new options select via click on option twice" do
+    visit new_options_combobox_path
+
+    field_selector = "allow-new"
+    open_combobox(field_selector)
+
+    assert_field field_selector, with: nil
+    assert_field "#{field_selector}-hw-hidden-field", type: "hidden", with: nil
+
+    find("li[role=option]", text: "Florida").click
+    assert_selector "input[aria-expanded=false]"
+    assert_field field_selector, with: "Florida"
+
+    open_combobox(field_selector)
+
+    find("li[role=option]", text: "Alabama").click
+    assert_selector "input[aria-expanded=false]"
+    assert_field field_selector, with: "Alabama"
+  end
+
   test "new options can be allowed" do
     assert_difference -> { State.count }, +1 do
       visit new_options_combobox_path


### PR DESCRIPTION
I noticed that for new options setup when user tries to select different option for second time it fails to change values, I added test to reproduce, not fixed it yet ;) 