### PR TITLE
Fix async comboboxes

### DIFF
--- a/app/assets/javascripts/controllers/hw_combobox_controller.js
+++ b/app/assets/javascripts/controllers/hw_combobox_controller.js
@@ -73,10 +73,10 @@ export default class HwComboboxController extends Concerns(...concerns) {
   endOfOptionsStreamTargetConnected(element) {
     const inputType = element.dataset.inputType
 
-    this._preselectOption()
-
     if (inputType) {
       this._commitFilter({ inputType })
+    } else {
+      this._preselectOption()
     }
   }
 }

--- a/app/assets/javascripts/hw_combobox/models/combobox/filtering.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/filtering.js
@@ -48,7 +48,7 @@ Combobox.Filtering = Base => class extends Base {
   // Consider +_query+ will contain the full autocompleted value
   // after a certain point in the call chain.
   get _query() {
-    return this._actingCombobox.value.trim()
+    return this._actingCombobox.value
   }
 
   set _query(value) {

--- a/test/system/hotwire_combobox_test.rb
+++ b/test/system/hotwire_combobox_test.rb
@@ -87,6 +87,18 @@ class HotwireComboboxTest < ApplicationSystemTestCase
     assert_no_visible_selected_option
   end
 
+  test "autocomplete with spaces in the query" do
+    visit async_path
+
+    open_combobox "#movie-field"
+    type_in_combobox "#movie-field", "12"
+    type_in_combobox "#movie-field", " "
+    sleep 0.5 # wait for async filter
+    type_in_combobox "#movie-field", "ang", :enter
+    sleep 0.5 # wait for async filter
+    assert_combobox_display_and_value "#movie-field", "12 Angry Men", movies("12_angry_men").id
+  end
+
   test "autocomplete only works when strings match from the very beginning, but the first option is still selected" do
     visit html_options_path
 


### PR DESCRIPTION
Regressed in https://github.com/josefarias/hotwire_combobox/pull/42

Trimming the query values was not allowing spaces as you type.

_hasValueButNoSelection is true when options are loaded async. So we shouldn't preselect if we're already filtering.

Sleep in tests aren't ideal but want to get a fix out there since the bug has been released in v0.1.34. Might clean up later.