### PR TITLE
Consider current selection in immediately autocompletable value

### DIFF
--- a/app/assets/javascripts/hw_combobox/models/combobox/autocomplete.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/autocomplete.js
@@ -30,14 +30,14 @@ Combobox.Autocomplete = Base => class extends Base {
   }
 
   get _isExactAutocompleteMatch() {
-    return this._immediatelyAutocompletableValue === this._typedQuery
+    return this._immediatelyAutocompletableValue === this._fullQuery
   }
 
   // All `_isExactAutocompleteMatch` matches are `_isPartialAutocompleteMatch` matches
   // but not all `_isPartialAutocompleteMatch` matches are `_isExactAutocompleteMatch` matches.
   get _isPartialAutocompleteMatch() {
     return !!this._immediatelyAutocompletableValue &&
-      startsWith(this._immediatelyAutocompletableValue, this._typedQuery)
+      startsWith(this._immediatelyAutocompletableValue, this._fullQuery)
   }
 
   get _autocompletesList() {
@@ -49,6 +49,6 @@ Combobox.Autocomplete = Base => class extends Base {
   }
 
   get _immediatelyAutocompletableValue() {
-    return this._visibleOptionElements[0]?.getAttribute(this.autocompletableAttributeValue)
+    return this._ensurableOption?.getAttribute(this.autocompletableAttributeValue)
   }
 }

--- a/app/assets/javascripts/hw_combobox/models/combobox/toggle.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/toggle.js
@@ -34,7 +34,6 @@ Combobox.Toggle = Base => class extends Base {
   closeOnFocusOutside({ target }) {
     if (!this._isOpen) return
     if (this.element.contains(target)) return
-    if (target.matches("main")) return
 
     this.close()
   }

--- a/test/system/hotwire_combobox_test.rb
+++ b/test/system/hotwire_combobox_test.rb
@@ -108,7 +108,6 @@ class HotwireComboboxTest < ApplicationSystemTestCase
     assert_selected_option_with selector: ".hw-combobox__option--selected", text: "Florida"
   end
 
-  focus
   test "selecting with the keyboard" do
     visit html_options_path
 

--- a/test/system/hotwire_combobox_test.rb
+++ b/test/system/hotwire_combobox_test.rb
@@ -108,6 +108,7 @@ class HotwireComboboxTest < ApplicationSystemTestCase
     assert_selected_option_with selector: ".hw-combobox__option--selected", text: "Florida"
   end
 
+  focus
   test "selecting with the keyboard" do
     visit html_options_path
 
@@ -119,6 +120,19 @@ class HotwireComboboxTest < ApplicationSystemTestCase
     type_in_combobox "#state-field", :enter
     assert_closed_combobox
     assert_combobox_display_and_value "#state-field", "Mississippi", "MS"
+
+    visit new_options_path
+
+    open_combobox "#movie-field"
+    type_in_combobox "#movie-field", "al"
+    assert_text "Aliens" # wait for async filter
+    type_in_combobox "#movie-field", :down, :down
+    assert_selected_option_with text: "Aliens"
+    type_in_combobox "#movie-field", :enter
+    assert_combobox_display_and_value "#movie-field", "Aliens", movies(:aliens).id
+
+    open_combobox "#movie-field"
+    assert_options_with count: 1 # Aliens
   end
 
   test "pressing enter locks in the current selection, but editing the text field resets it" do
@@ -351,7 +365,7 @@ class HotwireComboboxTest < ApplicationSystemTestCase
     open_combobox "#movie-field"
     type_in_combobox "#movie-field", "The Godfather"
     assert_text "The Godfather Part II" # wait for async filter
-    type_in_combobox "#movie-field", :backspace # clear autocompleted portion
+    clear_autocompleted_portion "#movie-field"
     tab_away # ensure selection
     assert_combobox_display_and_value "#movie-field", "The Godfather", "The Godfather"
     assert_proper_combobox_name_choice original: :movie, new: :new_movie, proper: :new
@@ -364,7 +378,7 @@ class HotwireComboboxTest < ApplicationSystemTestCase
 
     open_combobox "#movie-field"
     assert_options_with count: 1 # Part III
-    type_in_combobox "#movie-field", :backspace
+    delete_from_combobox "#movie-field", "I", original: "The Godfather Part III"
     assert_options_with count: 2 # Parts II and III
     tab_away # ensure selection
     assert_combobox_display_and_value "#movie-field", "The Godfather Part II", movies(:the_godfather_part_ii).id
@@ -456,7 +470,7 @@ class HotwireComboboxTest < ApplicationSystemTestCase
       type_in_combobox "#movie-field", "wh"
       assert_combobox_display_and_value "#movie-field", "Whiplash", movies(:whiplash).id
       assert_options_with count: 2
-      type_in_combobox "#movie-field", :backspace # clear autocompleted portion
+      clear_autocompleted_portion "#movie-field"
       delete_from_combobox "#movie-field", "wh", original: "wh"
       assert_combobox_display_and_value "#movie-field", "", nil
       assert_text "12 Angry Men"
@@ -534,6 +548,10 @@ class HotwireComboboxTest < ApplicationSystemTestCase
 
     def click_on_option(text)
       find("li[role=option]", text: text).click
+    end
+
+    def clear_autocompleted_portion(selector)
+      type_in_combobox selector, :backspace
     end
 
     def assert_combobox
@@ -631,7 +649,7 @@ class HotwireComboboxTest < ApplicationSystemTestCase
     end
 
     def tab_away
-      find("body").send_keys(:tab)
+      find("body").send_keys(:tab, :tab)
     end
 
     def click_away


### PR DESCRIPTION
I noticed _immediatelyAutocompletableValue was returning the wrong value when an option was selected by navigating with the keyboard and then pressing enter. This is because the first visible option was being used, instead of checking whether there's a selected option.