### PR TITLE
Only use <li> elements as listbox children

### DIFF
--- a/app/presenters/hotwire_combobox/component.rb
+++ b/app/presenters/hotwire_combobox/component.rb
@@ -77,11 +77,6 @@ class HotwireCombobox::Component
   end
 
 
-  def listbox_options_attrs
-    { id: listbox_options_id }
-  end
-
-
   def dialog_wrapper_attrs
     {
       class: "hw-combobox__dialog__wrapper"
@@ -257,11 +252,6 @@ class HotwireCombobox::Component
 
     def listbox_data
       { hw_combobox_target: "listbox" }
-    end
-
-
-    def listbox_options_id
-      "#{listbox_id}__options"
     end
 
 

--- a/app/views/hotwire_combobox/_next_page.turbo_stream.erb
+++ b/app/views/hotwire_combobox/_next_page.turbo_stream.erb
@@ -1,5 +1,6 @@
 <%# locals: (for_id:, next_page:, src:) -%>
 
-<%= turbo_stream.replace hw_pagination_frame_id(for_id) do %>
+<%= turbo_stream.remove hw_pagination_frame_wrapper_id(for_id) %>
+<%= turbo_stream.append hw_listbox_id(for_id) do %>
   <%= render "hotwire_combobox/pagination", for_id: for_id, src: hw_combobox_next_page_uri(src, next_page) %>
 <% end %>

--- a/app/views/hotwire_combobox/_paginated_options.turbo_stream.erb
+++ b/app/views/hotwire_combobox/_paginated_options.turbo_stream.erb
@@ -1,6 +1,6 @@
 <%# locals: (for_id:, options:) -%>
 
-<%= turbo_stream.public_send(hw_combobox_page_stream_action, hw_listbox_options_id(for_id)) do %>
+<%= turbo_stream.public_send(hw_combobox_page_stream_action, hw_listbox_id(for_id)) do %>
   <% options.each do |option| %>
     <%= render option %>
   <% end %>

--- a/app/views/hotwire_combobox/_pagination.html.erb
+++ b/app/views/hotwire_combobox/_pagination.html.erb
@@ -1,4 +1,7 @@
 <%# locals: (for_id:, src:) -%>
 
-<%= turbo_frame_tag hw_pagination_frame_id(for_id), src: src, loading: :lazy,
-      data: { hw_combobox_target: "endOfOptionsStream", input_type: params[:input_type] } %>
+<%= tag.li id: hw_pagination_frame_wrapper_id(for_id), data: {
+      hw_combobox_target: "endOfOptionsStream", input_type: params[:input_type] },
+      aria: { hidden: true } do %>
+  <%= turbo_frame_tag hw_pagination_frame_id(for_id), src: src, loading: :lazy %>
+<% end %>

--- a/app/views/hotwire_combobox/combobox/_paginated_listbox.html.erb
+++ b/app/views/hotwire_combobox/combobox/_paginated_listbox.html.erb
@@ -1,8 +1,6 @@
 <%= tag.ul **component.listbox_attrs do |ul| %>
-  <%= tag.div **component.listbox_options_attrs do %>
-    <% component.options.each do |option| %>
-      <%= render option %>
-    <% end %>
+  <% component.options.each do |option| %>
+    <%= render option %>
   <% end %>
 
   <% if component.paginated? %>

--- a/lib/hotwire_combobox/helper.rb
+++ b/lib/hotwire_combobox/helper.rb
@@ -45,8 +45,12 @@ module HotwireCombobox
     hw_alias :hw_async_combobox_options
 
     protected # library use only
-      def hw_listbox_options_id(id)
-        "#{id}-hw-listbox__options"
+      def hw_listbox_id(id)
+        "#{id}-hw-listbox"
+      end
+
+      def hw_pagination_frame_wrapper_id(id)
+        "#{id}__hw_combobox_pagination__wrapper"
       end
 
       def hw_pagination_frame_id(id)

--- a/test/helpers/hotwire_combobox/helper_test.rb
+++ b/test/helpers/hotwire_combobox/helper_test.rb
@@ -106,8 +106,8 @@ class HotwireCombobox::HelperTest < ApplicationViewTestCase
       rel: "stylesheet", href: "/stylesheets/hotwire_combobox.css"
   end
 
-  test "hw_listbox_options_id returns the same as component#listbox_options_id" do
-    assert_instance_of String, hw_listbox_options_id(:bar)
-    assert_equal hw_listbox_options_id(:bar), HotwireCombobox::Component.new(self, :foo, id: :bar).listbox_options_attrs[:id]
+  test "hw_listbox_id returns the same as component#listbox_id" do
+    assert_instance_of String, hw_listbox_id(:bar)
+    assert_equal hw_listbox_id(:bar), HotwireCombobox::Component.new(self, :foo, id: :bar).listbox_attrs[:id]
   end
 end


### PR DESCRIPTION
Addresses one of the issues in https://github.com/josefarias/hotwire_combobox/issues/25