### PR TITLE
Turn off native html autocomplete by default

### DIFF
--- a/app/presenters/hotwire_combobox/component.rb
+++ b/app/presenters/hotwire_combobox/component.rb
@@ -53,8 +53,9 @@ class HotwireCombobox::Component
       class: "hw-combobox__input",
       type: input_type,
       data: input_data,
-      aria: input_aria
-    }.merge combobox_attrs.except(*nested_attrs)
+      aria: input_aria,
+      autocomplete: :off
+    }.with_indifferent_access.merge combobox_attrs.except(*nested_attrs)
   end
 
 

--- a/test/presenters/hotwire_combobox/component_test.rb
+++ b/test/presenters/hotwire_combobox/component_test.rb
@@ -1,0 +1,15 @@
+require "test_helper"
+
+class HotwireCombobox::ComponentTest < ApplicationViewTestCase
+  test "native html autocomplete is off by default" do
+    HotwireCombobox::Component.new(view, :foo).tap do |component|
+      assert_equal :off, component.input_attrs[:autocomplete]
+    end
+  end
+
+  test "native html autocomplete can be turned on" do
+    HotwireCombobox::Component.new(view, :foo, input: { autocomplete: :on }).tap do |component|
+      assert_equal :on, component.input_attrs[:autocomplete]
+    end
+  end
+end


### PR DESCRIPTION
Addresses one of the issues in https://github.com/josefarias/hotwire_combobox/issues/25

Users can still turn it on by passing any of the [supported values](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#values) as follows:

```erb
<%= combobox_tag :foo, [], input: { autocomplete: desired_value }) %>
```