### PR TITLE
@states -> @state_options

### DIFF
--- a/test/dummy/app/controllers/comboboxes_controller.rb
+++ b/test/dummy/app/controllers/comboboxes_controller.rb
@@ -55,7 +55,7 @@ class ComboboxesController < ApplicationController
     delegate :combobox_options, :html_combobox_options, to: "ApplicationController.helpers", private: true
 
     def set_states
-      @states = combobox_options State.all, id: :abbreviation, value: :abbreviation, display: :name
+      @state_options = combobox_options State.all, id: :abbreviation, value: :abbreviation, display: :name
     end
 
     def aside_nav?

--- a/test/dummy/app/views/comboboxes/formbuilder.html.erb
+++ b/test/dummy/app/views/comboboxes/formbuilder.html.erb
@@ -1,4 +1,4 @@
 <%= form_with do |form| %>
-  <%= form.combobox "state", @states, id: "state-field" %>
+  <%= form.combobox "state", @state_options, id: "state-field" %>
   <%= form.submit %>
 <% end %>

--- a/test/dummy/app/views/comboboxes/html_options.html.erb
+++ b/test/dummy/app/views/comboboxes/html_options.html.erb
@@ -39,11 +39,11 @@
 </style>
 
 <%
-  @states = combobox_options State.all,
+  @state_options = combobox_options State.all,
     id: :abbreviation,
     value: :abbreviation,
     display: :name,
     render_in: { partial: "states/state" }
 %>
 
-<%= combobox_tag "state", @states, id: "state-field" %>
+<%= combobox_tag "state", @state_options, id: "state-field" %>

--- a/test/dummy/app/views/comboboxes/inline_autocomplete.html.erb
+++ b/test/dummy/app/views/comboboxes/inline_autocomplete.html.erb
@@ -1,1 +1,1 @@
-<%= combobox_tag "state", @states, id: "state-field", autocomplete: :inline %>
+<%= combobox_tag "state", @state_options, id: "state-field", autocomplete: :inline %>

--- a/test/dummy/app/views/comboboxes/list_autocomplete.html.erb
+++ b/test/dummy/app/views/comboboxes/list_autocomplete.html.erb
@@ -1,1 +1,1 @@
-<%= combobox_tag "state", @states, id: "state-field", autocomplete: :list %>
+<%= combobox_tag "state", @state_options, id: "state-field", autocomplete: :list %>

--- a/test/dummy/app/views/comboboxes/open.html.erb
+++ b/test/dummy/app/views/comboboxes/open.html.erb
@@ -1,1 +1,1 @@
-<%= combobox_tag "state", @states, id: "state-field", open: true %>
+<%= combobox_tag "state", @state_options, id: "state-field", open: true %>

--- a/test/dummy/app/views/comboboxes/plain.html.erb
+++ b/test/dummy/app/views/comboboxes/plain.html.erb
@@ -1,3 +1,3 @@
-<%= combobox_tag "state", @states, id: "state-field" %>
+<%= combobox_tag "state", @state_options, id: "state-field" %>
 
 <%= button_tag "focusable element" %>

--- a/test/dummy/app/views/comboboxes/prefilled.html.erb
+++ b/test/dummy/app/views/comboboxes/prefilled.html.erb
@@ -1,1 +1,1 @@
-<%= combobox_tag "state", @states, value: "MI", id: "state-field" %>
+<%= combobox_tag "state", @state_options, value: "MI", id: "state-field" %>

--- a/test/dummy/app/views/comboboxes/required.html.erb
+++ b/test/dummy/app/views/comboboxes/required.html.erb
@@ -2,5 +2,5 @@
   .invalid { border: 1px solid red; }
 </style>
 
-<%= combobox_tag "state", @states, id: "state-field", required: true,
+<%= combobox_tag "state", @state_options, id: "state-field", required: true,
       data: { "hw-combobox-invalid-class": "invalid" } %>


### PR DESCRIPTION
Using the options helper predates being able to pass the relation directly. We shouldn't use it going forward as it's not how most users will interact with the library.

It's too easy to think `@states` contains a collection of State objects instead of an options array.