### PR TITLE
Add assets instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,19 @@ Add this line to your application's Gemfile and run `bundle install`:
 gem "hotwire_combobox"
 ```
 
-Only apps that use importmaps are currently supported. Suport for other JS solutions is in progress.
+Then add the stylesheet to your layout:
+
+```erb
+<%= combobox_style_tag %>
+```
+
+Or add require the styles with the asset pipeline in `app/assets/stylesheets/application.css`:
+
+```erb
+*= require hotwire_combobox
+```
+
+Only apps that use importmaps are currently supported. Support for other JS solutions is in progress.
 
 ## Docs
 


### PR DESCRIPTION
This adds the stylesheet tag and asset pipeline instructions to the readme.

It took me a bit to find these instructions 

Also might want to add something for Propshaft as that will be the default in Rails 8. I believe the engine could simply add itself to `config.assets.paths` though so that might be more seamless.