### PR TITLE
Make `:for_id` optional in async options

### DIFF
--- a/app/assets/javascripts/hw_combobox/models/combobox/filtering.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/filtering.js
@@ -21,7 +21,12 @@ Combobox.Filtering = Base => class extends Base {
   }
 
   async _filterAsync(event) {
-    const query = { q: this._fullQuery, input_type: event.inputType }
+    const query = {
+      q: this._fullQuery,
+      input_type: event.inputType,
+      for_id: this.element.dataset.asyncId
+    }
+
     await get(this.asyncSrcValue, { responseKind: "turbo-stream", query })
   }
 

--- a/app/presenters/hotwire_combobox/component.rb
+++ b/app/presenters/hotwire_combobox/component.rb
@@ -1,5 +1,5 @@
 class HotwireCombobox::Component
-  attr_reader :async_src, :options, :dialog_label
+  attr_reader :options, :dialog_label
 
   def initialize \
       view, name,
@@ -179,6 +179,10 @@ class HotwireCombobox::Component
 
     def association_exists?
       form&.object&.class&.reflect_on_association(association_name).present?
+    end
+
+    def async_src
+      view.hw_uri_with_params @async_src, for_id: canonical_id, format: :turbo_stream
     end
 
 

--- a/app/views/hotwire_combobox/_next_page.turbo_stream.erb
+++ b/app/views/hotwire_combobox/_next_page.turbo_stream.erb
@@ -2,5 +2,5 @@
 
 <%= turbo_stream.remove hw_pagination_frame_wrapper_id(for_id) %>
 <%= turbo_stream.append hw_listbox_id(for_id) do %>
-  <%= render "hotwire_combobox/pagination", for_id: for_id, src: hw_combobox_next_page_uri(src, next_page) %>
+  <%= render "hotwire_combobox/pagination", for_id: for_id, src: hw_combobox_next_page_uri(src, next_page, for_id) %>
 <% end %>

--- a/lib/hotwire_combobox/helper.rb
+++ b/lib/hotwire_combobox/helper.rb
@@ -33,7 +33,7 @@ module HotwireCombobox
     end
     hw_alias :hw_combobox_options
 
-    def hw_paginated_combobox_options(options, for_id:, src: request.path, next_page: nil, render_in: {}, **methods)
+    def hw_paginated_combobox_options(options, for_id: params[:for_id], src: request.path, next_page: nil, render_in: {}, **methods)
       this_page = render("hotwire_combobox/paginated_options", for_id: for_id, options: hw_combobox_options(options, render_in: render_in, **methods))
       next_page = render("hotwire_combobox/next_page", for_id: for_id, src: src, next_page: next_page)
 
@@ -44,7 +44,7 @@ module HotwireCombobox
     alias_method :hw_async_combobox_options, :hw_paginated_combobox_options
     hw_alias :hw_async_combobox_options
 
-    protected # library use only
+    # private library use only
       def hw_listbox_id(id)
         "#{id}-hw-listbox"
       end
@@ -57,23 +57,14 @@ module HotwireCombobox
         "#{id}__hw_combobox_pagination"
       end
 
-      def hw_combobox_next_page_uri(uri, next_page)
+      def hw_combobox_next_page_uri(uri, next_page, for_id)
         if next_page
-          hw_uri_with_params uri, page: next_page, q: params[:q], format: :turbo_stream
+          hw_uri_with_params uri, page: next_page, q: params[:q], for_id: for_id, format: :turbo_stream
         end
       end
 
       def hw_combobox_page_stream_action
         params[:page] ? :append : :update
-      end
-
-    private
-      def hw_extract_options_and_src(options_or_src, render_in)
-        if options_or_src.is_a? String
-          [ [], hw_uri_with_params(options_or_src, format: :turbo_stream) ]
-        else
-          [ hw_combobox_options(options_or_src, render_in: render_in), nil ]
-        end
       end
 
       def hw_uri_with_params(url_or_path, **params)
@@ -83,6 +74,15 @@ module HotwireCombobox
         end.to_s
       rescue URI::InvalidURIError
         url_or_path
+      end
+
+    private
+      def hw_extract_options_and_src(options_or_src, render_in)
+        if options_or_src.is_a? String
+          [ [], options_or_src ]
+        else
+          [ hw_combobox_options(options_or_src, render_in: render_in), nil ]
+        end
       end
 
       def hw_parse_combobox_options(options, render_in: nil, **methods)

--- a/test/dummy/app/views/movies/index.turbo_stream.erb
+++ b/test/dummy/app/views/movies/index.turbo_stream.erb
@@ -1,3 +1,2 @@
 <%= hw_async_combobox_options @page.records,
-      for_id: "movie-field",
       next_page: @page.last? ? nil : @page.next_param %>

--- a/test/dummy/app/views/movies/index_html.turbo_stream.erb
+++ b/test/dummy/app/views/movies/index_html.turbo_stream.erb
@@ -1,4 +1,3 @@
 <%= hw_async_combobox_options @page.records,
       render_in: { partial: "movies/movie" },
-      for_id: "movie-field",
       next_page: @page.last? ? nil : @page.next_param %>


### PR DESCRIPTION
Closes https://github.com/josefarias/hotwire_combobox/discussions/62

In most cases, the async combobox's id can be inferred from the incoming filter request. If we do that, then you don't need to pass `:for_id` most of the time.

The kwarg is still supported, so you can still specify an id if you absolutely need to.