### PR TITLE
Generate an id if one is not passed to combobox

### DIFF
--- a/app/presenters/hotwire_combobox/component.rb
+++ b/app/presenters/hotwire_combobox/component.rb
@@ -1,3 +1,5 @@
+require "securerandom"
+
 class HotwireCombobox::Component
   attr_reader :options, :dialog_label
 
@@ -187,7 +189,7 @@ class HotwireCombobox::Component
 
 
     def canonical_id
-      id || form&.field_id(name)
+      id || form&.field_id(name) || SecureRandom.uuid
     end
 
 


### PR DESCRIPTION
Not passing an id and rendering more than one combobox means several combobox elements will have the same id, since we build all nested element ids relative to the `canonical_id`.