### PR TITLE
Add Gemfile.lock platforms

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,6 +152,8 @@ GEM
     nio4r (2.7.0)
     nokogiri (1.16.2-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.16.2-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.16.2-x86_64-linux)
       racc (~> 1.4)
     parallel (1.24.0)
@@ -260,6 +262,7 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     sqlite3 (1.7.2-arm64-darwin)
+    sqlite3 (1.7.2-x86_64-darwin)
     sqlite3 (1.7.2-x86_64-linux)
     stimulus-rails (1.3.3)
       railties (>= 6.0.0)
@@ -288,6 +291,8 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
Each time I run `bundle install` to get updated dependencies here - both on my work and personal laptops - I'm getting minor platform-related changes to `Gemfile.lock`. This should prevent that noise going forward.

_Another pattern I've seen and used is to add `Gemfile.lock` to `.gitignore` (since unlike a production app we shouldn't need to be too concerned about exact matching dependencies while working on a library), but I thought it best to start with the smallest solution._