### PR TITLE
Deisolate engine

### DIFF
--- a/lib/hotwire_combobox/engine.rb
+++ b/lib/hotwire_combobox/engine.rb
@@ -1,7 +1,5 @@
 module HotwireCombobox
   class Engine < ::Rails::Engine
-    isolate_namespace HotwireCombobox
-
     initializer "hotwire_combobox.view_helpers" do
       ActiveSupport.on_load :action_view do
         require "hotwire_combobox/helper"


### PR DESCRIPTION
Closes https://github.com/josefarias/hotwire_combobox/issues/89

Should be fine as we don't use any routes or models for the gem. And I don't think we will, either.