### PR TITLE
Pass display and value as locals to render_in evals

### DIFF
--- a/test/dummy/app/controllers/comboboxes_controller.rb
+++ b/test/dummy/app/controllers/comboboxes_controller.rb
@@ -66,6 +66,10 @@ class ComboboxesController < ApplicationController
   def conflicting_order
   end
 
+  def render_in_locals
+    @hashes = State.limit(3).map { |state| { display: state.name, value: state.abbreviation } }
+  end
+
   private
     delegate :combobox_options, :html_combobox_options, to: "ApplicationController.helpers", private: true
 

--- a/test/dummy/app/views/comboboxes/render_in_locals.erb
+++ b/test/dummy/app/views/comboboxes/render_in_locals.erb
@@ -1,0 +1,1 @@
+<%= combobox_tag :state, @hashes, id: "state-field", render_in: { partial: "states/destructured_state" } %>

--- a/test/dummy/app/views/states/_destructured_state.html.erb
+++ b/test/dummy/app/views/states/_destructured_state.html.erb
@@ -1,0 +1,4 @@
+<p>
+  display: <%= combobox_display %><br>
+  value: <%= combobox_value %>
+</p>

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
   get "custom_events", to: "comboboxes#custom_events"
   get "custom_attrs", to: "comboboxes#custom_attrs"
   get "conflicting_order", to: "comboboxes#conflicting_order"
+  get "render_in_locals", to: "comboboxes#render_in_locals"
 
   resources :movies, only: %i[ index update ]
   get "movies_html", to: "movies#index_html"

--- a/test/system/hotwire_combobox_test.rb
+++ b/test/system/hotwire_combobox_test.rb
@@ -768,6 +768,13 @@ class HotwireComboboxTest < ApplicationSystemTestCase
     assert_combobox_display_and_value "#conflicting-order", "A", "A"
   end
 
+  test "render_in locals" do
+    visit render_in_locals_path
+
+    open_combobox "#state-field"
+    assert_option_with text: "display: Alabama\nvalue: AL"
+  end
+
   private
     def open_combobox(selector)
       find(selector).click


### PR DESCRIPTION
Closes https://github.com/josefarias/hotwire_combobox/issues/101

Display and value are now accessible as locals in the partials passed to `:render_in`. You can access them via `combobox_display` and `combobox_value`.

Passing an `ActiveRecord::Relation` or an array of objects as the second parameter to `combobox_tag` are the only cases where the rendered object is an active record (so, when rendering `partial: "colors/color"`, calling `color` returns the active record). In all other cases, the rendered object is the display text — that is, the text that's used for filtering and autocompleting.