### PR TITLE
Skip extra item selection events when clicking an option

### DIFF
--- a/app/assets/javascripts/hw_combobox/models/combobox/filtering.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/filtering.js
@@ -45,7 +45,7 @@ Combobox.Filtering = Base => class extends Base {
       this._deselect()
     } else if (event.inputType === "hw:lockInSelection") {
       this._select(this._ensurableOption)
-    } else if (this._isOpen) {
+    } else if (this._isOpen && this._fullQuery) {
       this._select(this._visibleOptionElements[0])
     }
   }

--- a/app/assets/javascripts/hw_combobox/models/combobox/selection.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/selection.js
@@ -5,7 +5,7 @@ Combobox.Selection = Base => class extends Base {
   selectOptionOnClick(event) {
     this.filter(event)
     this._select(event.currentTarget, { forceAutocomplete: true })
-    this.close({ optionDirectlyClicked: true })
+    this.close()
   }
 
   _connectSelection() {

--- a/app/assets/javascripts/hw_combobox/models/combobox/selection.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/selection.js
@@ -5,7 +5,7 @@ Combobox.Selection = Base => class extends Base {
   selectOptionOnClick(event) {
     this.filter(event)
     this._select(event.currentTarget, { forceAutocomplete: true })
-    this.close()
+    this.close({ optionDirectlyClicked: true })
   }
 
   _connectSelection() {
@@ -15,7 +15,7 @@ Combobox.Selection = Base => class extends Base {
   }
 
   _select(option, { forceAutocomplete = false } = {}) {
-    this._resetOptions()
+    if (option !== this._selectedOptionElement) this._resetOptions()
 
     if (option) {
       this._autocompleteWith(option, { force: forceAutocomplete })
@@ -27,6 +27,8 @@ Combobox.Selection = Base => class extends Base {
   }
 
   _commitSelection(option, { selected }) {
+    if (selected && option === this._selectedOptionElement) return
+
     this._markSelected(option, { selected })
 
     if (selected) {


### PR DESCRIPTION
While working on #108, I noticed some odd behavior around item selection that only manifested as a bug with the multiple selection. I simply added some extra conditionals in that PR because I hadn't yet worked out any clean fixes.

The first commit here addresses only the very first odd behavior - when I click on an option in the list, the first item is incorrectly selected before resolving on the actual option I clicked.

I verified this by adding the following:

![debugging](https://github.com/josefarias/hotwire_combobox/assets/96935/6d99f74b-7c48-446e-b76f-a538ebc064ef)

which resulted in:

![debugging output](https://github.com/josefarias/hotwire_combobox/assets/96935/acbba872-4745-41f8-85ea-e391958dd4ae)

---

The second commit here addresses both of the de-selection and re-selection events, seen here originally in a bit more detail:

![reselections](https://github.com/josefarias/hotwire_combobox/assets/96935/9152fd98-d4d6-4cd4-bbc0-354ad315b778)

and now has been removed without breaking any system tests (and passing minimal manual testing):

![no-more-reselection](https://github.com/josefarias/hotwire_combobox/assets/96935/5892e871-8c4c-4f0c-b76b-b57ad4e75710)
