### PR TITLE
Detangle autocompletion, selection, and filtering

### DIFF
--- a/app/assets/javascripts/controllers/hw_combobox_controller.js
+++ b/app/assets/javascripts/controllers/hw_combobox_controller.js
@@ -80,7 +80,7 @@ export default class HwComboboxController extends Concerns(...concerns) {
 
     if (inputType && inputType !== "hw:lockInSelection") {
       if (delay) await sleep(delay)
-      this._commitFilter({ inputType })
+      this._selectBasedOnQuery({ inputType })
     } else {
       this._preselectOption()
     }

--- a/app/assets/javascripts/hw_combobox/models/combobox/async_loading.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/async_loading.js
@@ -4,4 +4,8 @@ Combobox.AsyncLoading = Base => class extends Base {
   get _isAsync() {
     return this.hasAsyncSrcValue
   }
+
+  get _isSync() {
+    return !this._isAsync
+  }
 }

--- a/app/assets/javascripts/hw_combobox/models/combobox/autocomplete.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/autocomplete.js
@@ -8,16 +8,18 @@ Combobox.Autocomplete = Base => class extends Base {
     }
   }
 
-  _autocompleteWith(option, { force }) {
-    if (!this._autocompletesInline && !force) return
+  _replaceFullQueryWithAutocompletedValue(option) {
+    const autocompletedValue = option.getAttribute(this.autocompletableAttributeValue)
 
+    this._fullQuery = autocompletedValue
+    this._actingCombobox.setSelectionRange(autocompletedValue.length, autocompletedValue.length)
+  }
+
+  _autocompleteMissingPortionOnly(option) {
     const typedValue = this._typedQuery
     const autocompletedValue = option.getAttribute(this.autocompletableAttributeValue)
 
-    if (force) {
-      this._fullQuery = autocompletedValue
-      this._actingCombobox.setSelectionRange(autocompletedValue.length, autocompletedValue.length)
-    } else if (startsWith(autocompletedValue, typedValue)) {
+    if (this._autocompletesInline && startsWith(autocompletedValue, typedValue)) {
       this._fullQuery = autocompletedValue
       this._actingCombobox.setSelectionRange(typedValue.length, autocompletedValue.length)
     }

--- a/app/assets/javascripts/hw_combobox/models/combobox/autocomplete.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/autocomplete.js
@@ -15,7 +15,7 @@ Combobox.Autocomplete = Base => class extends Base {
     this._actingCombobox.setSelectionRange(autocompletedValue.length, autocompletedValue.length)
   }
 
-  _autocompleteMissingPortionOnly(option) {
+  _autocompleteMissingPortion(option) {
     const typedValue = this._typedQuery
     const autocompletedValue = option.getAttribute(this.autocompletableAttributeValue)
 

--- a/app/assets/javascripts/hw_combobox/models/combobox/events.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/events.js
@@ -2,8 +2,13 @@ import Combobox from "hw_combobox/models/combobox/base"
 import { dispatch } from "hw_combobox/helpers"
 
 Combobox.Events = Base => class extends Base {
-  _dispatchSelectionEvent({ isNew }) {
-    dispatch("hw-combobox:selection", { target: this.element, detail: { ...this._eventableDetails, isNew } })
+  _dispatchSelectionEvent({ isNewAndAllowed, previousValue }) {
+    if (previousValue !== this._value) {
+      dispatch("hw-combobox:selection", {
+        target: this.element,
+        detail: { ...this._eventableDetails, isNewAndAllowed, previousValue }
+      })
+    }
   }
 
   _dispatchClosedEvent() {
@@ -12,7 +17,7 @@ Combobox.Events = Base => class extends Base {
 
   get _eventableDetails() {
     return {
-      value: this.hiddenFieldTarget.value,
+      value: this._value,
       display: this._fullQuery,
       query: this._typedQuery,
       fieldName: this.hiddenFieldTarget.name,

--- a/app/assets/javascripts/hw_combobox/models/combobox/filtering.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/filtering.js
@@ -48,7 +48,7 @@ Combobox.Filtering = Base => class extends Base {
     } else if (this._isOpen && this._visibleOptionElements[0]) {
       this._selectAndAutocompleteMissingPortion(this._visibleOptionElements[0])
     } else if (this._isOpen) {
-      this._resetOptions()
+      this._resetOptionsAndNotify()
       this._markInvalid()
     }
   }

--- a/app/assets/javascripts/hw_combobox/models/combobox/filtering.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/filtering.js
@@ -43,10 +43,13 @@ Combobox.Filtering = Base => class extends Base {
       this._selectNew()
     } else if (isDeleteEvent(event)) {
       this._deselect()
-    } else if (event.inputType === "hw:lockInSelection") {
+    } else if (event.inputType === "hw:lockInSelection" && this._ensurableOption) {
       this._selectAndAutocompleteMissingPortion(this._ensurableOption)
-    } else if (this._isOpen) {
+    } else if (this._isOpen && this._visibleOptionElements[0]) {
       this._selectAndAutocompleteMissingPortion(this._visibleOptionElements[0])
+    } else if (this._isOpen) {
+      this._resetOptions()
+      this._markInvalid()
     }
   }
 

--- a/app/assets/javascripts/hw_combobox/models/combobox/filtering.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/filtering.js
@@ -44,9 +44,9 @@ Combobox.Filtering = Base => class extends Base {
     } else if (isDeleteEvent(event)) {
       this._deselect()
     } else if (event.inputType === "hw:lockInSelection") {
-      this._select(this._ensurableOption)
+      this._selectAndAutocompleteMissingPortion(this._ensurableOption)
     } else if (this._isOpen) {
-      this._select(this._visibleOptionElements[0])
+      this._selectAndAutocompleteMissingPortion(this._visibleOptionElements[0])
     }
   }
 

--- a/app/assets/javascripts/hw_combobox/models/combobox/filtering.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/filtering.js
@@ -1,21 +1,31 @@
 
 import Combobox from "hw_combobox/models/combobox/base"
-import { applyFilter, debounce, isDeleteEvent, unselectedPortion } from "hw_combobox/helpers"
+import { applyFilter, debounce, unselectedPortion } from "hw_combobox/helpers"
 import { get } from "hw_combobox/vendor/requestjs"
 
 Combobox.Filtering = Base => class extends Base {
-  filter(event) {
-    if (this._isAsync) {
-      this._debouncedFilterAsync(event)
-    } else {
-      this._filterSync(event)
-    }
+  filterAndSelect(event) {
+    this._filter(event)
 
-    this._actingCombobox.toggleAttribute("data-queried", this._isQueried)
+    if (this._isSync) {
+      this._selectBasedOnQuery(event)
+    } else {
+      // noop, async selection is handled by stimulus callbacks
+    }
   }
 
   _initializeFiltering() {
     this._debouncedFilterAsync = debounce(this._debouncedFilterAsync.bind(this))
+  }
+
+  _filter(event) {
+    if (this._isAsync) {
+      this._debouncedFilterAsync(event)
+    } else {
+      this._filterSync()
+    }
+
+    this._actingCombobox.toggleAttribute("data-queried", this._isQueried)
   }
 
   _debouncedFilterAsync(event) {
@@ -32,30 +42,14 @@ Combobox.Filtering = Base => class extends Base {
     await get(this.asyncSrcValue, { responseKind: "turbo-stream", query })
   }
 
-  _filterSync(event) {
+  _filterSync() {
     this.open()
     this._allOptionElements.forEach(applyFilter(this._fullQuery, { matching: this.filterableAttributeValue }))
-    this._commitFilter(event)
-  }
-
-  _commitFilter(event) {
-    if (this._shouldTreatAsNewOptionForFiltering(!isDeleteEvent(event))) {
-      this._selectNew()
-    } else if (isDeleteEvent(event)) {
-      this._deselect()
-    } else if (event.inputType === "hw:lockInSelection" && this._ensurableOption) {
-      this._selectAndAutocompleteMissingPortion(this._ensurableOption)
-    } else if (this._isOpen && this._visibleOptionElements[0]) {
-      this._selectAndAutocompleteMissingPortion(this._visibleOptionElements[0])
-    } else if (this._isOpen) {
-      this._resetOptionsAndNotify()
-      this._markInvalid()
-    }
   }
 
   _clearQuery() {
     this._fullQuery = ""
-    this.filter({ inputType: "deleteContentBackward" })
+    this.filterAndSelect({ inputType: "deleteContentBackward" })
   }
 
   get _isQueried() {

--- a/app/assets/javascripts/hw_combobox/models/combobox/options.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/options.js
@@ -2,9 +2,17 @@ import Combobox from "hw_combobox/models/combobox/base"
 import { visible } from "hw_combobox/helpers"
 
 Combobox.Options = Base => class extends Base {
-  _resetOptions() {
-    this._deselect()
+  _resetOptionsSilently() {
+    this._resetOptions(this._deselect.bind(this))
+  }
+
+  _resetOptionsAndNotify() {
+    this._resetOptions(this._deselectAndNotify.bind(this))
+  }
+
+  _resetOptions(deselectionStrategy) {
     this._setName(this.originalNameValue)
+    deselectionStrategy()
   }
 
   get _allowNew() {

--- a/app/assets/javascripts/hw_combobox/models/combobox/options.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/options.js
@@ -4,7 +4,7 @@ import { visible } from "hw_combobox/helpers"
 Combobox.Options = Base => class extends Base {
   _resetOptions() {
     this._deselect()
-    this.hiddenFieldTarget.name = this.originalNameValue
+    this._setName(this.originalNameValue)
   }
 
   get _allowNew() {
@@ -32,7 +32,7 @@ Combobox.Options = Base => class extends Base {
   }
 
   get _isUnjustifiablyBlank() {
-    const valueIsMissing = !this.hiddenFieldTarget.value
+    const valueIsMissing = !this._value
     const noBlankOptionSelected = !this._selectedOptionElement
 
     return valueIsMissing && noBlankOptionSelected

--- a/app/assets/javascripts/hw_combobox/models/combobox/selection.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/selection.js
@@ -25,6 +25,13 @@ Combobox.Selection = Base => class extends Base {
     } else if (this._isOpen) {
       this._resetOptionsAndNotify()
       this._markInvalid()
+    } else {
+      // When selecting from an async dialog listbox: selection is forced, the listbox is filtered,
+      // and the dialog is closed. Filtering ends with an `endOfOptionsStream` target connected
+      // to the now invisible combobox, which is now closed because Turbo waits for "nextRepaint"
+      // before rendering turbo streams. This ultimately calls +_selectBasedOnQuery+. We do want
+      // to call +_selectBasedOnQuery+ in this case to account for e.g. selection of
+      // new options. But we will noop here if it's none of the cases checked above.
     }
   }
 

--- a/app/assets/javascripts/hw_combobox/models/combobox/selection.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/selection.js
@@ -20,7 +20,12 @@ Combobox.Selection = Base => class extends Base {
     if (option) {
       const previousValue = this._value
 
-      this._autocompleteWith(option, { force: forceAutocomplete })
+      if (forceAutocomplete) {
+        this._replaceFullQueryWithAutocompletedValue(option)
+      } else {
+        this._autocompleteMissingPortionOnly(option)
+      }
+
       this._setValue(option.dataset.value)
       this._markSelected(option)
       this._markValid()

--- a/app/assets/javascripts/hw_combobox/models/combobox/selection.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/selection.js
@@ -95,11 +95,6 @@ Combobox.Selection = Base => class extends Base {
       this._selectAndReplaceFullQuery(this._ensurableOption)
       this.filter({ inputType: "hw:lockInSelection" })
     }
-
-    if (this._isUnjustifiablyBlank) {
-      this._deselect()
-      this._clearQuery()
-    }
   }
 
   _setActiveDescendant(id) {

--- a/app/assets/javascripts/hw_combobox/models/combobox/selection.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/selection.js
@@ -27,7 +27,11 @@ Combobox.Selection = Base => class extends Base {
   }
 
   _commitSelection(option, { selected }) {
-    this._markSelected(option, { selected })
+    if (selected) {
+      this._markSelected(option)
+    } else {
+      this._markNotSelected(option)
+    }
 
     if (selected) {
       this.hiddenFieldTarget.value = option.dataset.value
@@ -37,13 +41,16 @@ Combobox.Selection = Base => class extends Base {
     this._dispatchSelectionEvent({ isNew: false })
   }
 
-  _markSelected(option, { selected }) {
-    if (this.hasSelectedClass) {
-      option.classList.toggle(this.selectedClass, selected)
-    }
+  _markSelected(option) {
+    if (this.hasSelectedClass) option.classList.add(this.selectedClass)
+    option.setAttribute("aria-selected", true)
+    this._setActiveDescendant(option.id)
+  }
 
-    option.setAttribute("aria-selected", selected)
-    this._setActiveDescendant(selected ? option.id : "")
+  _markNotSelected(option) {
+    if (this.hasSelectedClass) option.classList.remove(this.selectedClass)
+    option.removeAttribute("aria-selected")
+    this._removeActiveDescendant()
   }
 
   _deselect() {
@@ -77,7 +84,7 @@ Combobox.Selection = Base => class extends Base {
         return option.dataset.value === this.hiddenFieldTarget.value
       })
 
-      if (option) this._markSelected(option, { selected: true })
+      if (option) this._markSelected(option)
     }
   }
 
@@ -95,6 +102,10 @@ Combobox.Selection = Base => class extends Base {
 
   _setActiveDescendant(id) {
     this._forAllComboboxes(el => el.setAttribute("aria-activedescendant", id))
+  }
+
+  _removeActiveDescendant() {
+    this._setActiveDescendant("")
   }
 
   get _hasValueButNoSelection() {

--- a/app/assets/javascripts/hw_combobox/models/combobox/selection.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/selection.js
@@ -23,22 +23,18 @@ Combobox.Selection = Base => class extends Base {
   }
 
   _select(option, autocompleteStrategy) {
+    const previousValue = this._value
+
     this._resetOptions()
 
-    if (option) {
-      const previousValue = this._value
+    autocompleteStrategy(option)
 
-      autocompleteStrategy(option)
+    this._setValue(option.dataset.value)
+    this._markSelected(option)
+    this._markValid()
+    this._dispatchSelectionEvent({ isNewAndAllowed: false, previousValue: previousValue })
 
-      this._setValue(option.dataset.value)
-      this._markSelected(option)
-      this._markValid()
-      this._dispatchSelectionEvent({ isNewAndAllowed: false, previousValue: previousValue })
-
-      option.scrollIntoView({ block: "nearest" })
-    } else {
-      this._markInvalid()
-    }
+    option.scrollIntoView({ block: "nearest" })
   }
 
   _selectNew() {

--- a/app/assets/javascripts/hw_combobox/models/combobox/selection.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/selection.js
@@ -107,7 +107,7 @@ Combobox.Selection = Base => class extends Base {
   }
 
   _selectAndAutocompleteMissingPortion(option) {
-    this._select(option, this._autocompleteMissingPortionOnly.bind(this))
+    this._select(option, this._autocompleteMissingPortion.bind(this))
   }
 
   _lockInSelection() {

--- a/app/assets/javascripts/hw_combobox/models/combobox/selection.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/selection.js
@@ -4,7 +4,7 @@ import { wrapAroundAccess } from "hw_combobox/helpers"
 Combobox.Selection = Base => class extends Base {
   selectOptionOnClick(event) {
     this.filter(event)
-    this._select(event.currentTarget, { forceAutocomplete: true })
+    this._selectAndReplaceFullQuery(event.currentTarget)
     this.close()
   }
 
@@ -14,17 +14,21 @@ Combobox.Selection = Base => class extends Base {
     }
   }
 
-  _select(option, { forceAutocomplete = false } = {}) {
+  _selectAndReplaceFullQuery(option) {
+    this._select(option, this._replaceFullQueryWithAutocompletedValue.bind(this))
+  }
+
+  _selectAndAutocompleteMissingPortion(option) {
+    this._select(option, this._autocompleteMissingPortionOnly.bind(this))
+  }
+
+  _select(option, autocompleteStrategy) {
     this._resetOptions()
 
     if (option) {
       const previousValue = this._value
 
-      if (forceAutocomplete) {
-        this._replaceFullQueryWithAutocompletedValue(option)
-      } else {
-        this._autocompleteMissingPortionOnly(option)
-      }
+      autocompleteStrategy(option)
 
       this._setValue(option.dataset.value)
       this._markSelected(option)
@@ -73,7 +77,7 @@ Combobox.Selection = Base => class extends Base {
 
   _selectIndex(index) {
     const option = wrapAroundAccess(this._visibleOptionElements, index)
-    this._select(option, { forceAutocomplete: true })
+    this._selectAndReplaceFullQuery(option)
   }
 
   _preselectOption() {
@@ -88,7 +92,7 @@ Combobox.Selection = Base => class extends Base {
 
   _lockInSelection() {
     if (this._shouldLockInSelection) {
-      this._select(this._ensurableOption, { forceAutocomplete: true })
+      this._selectAndReplaceFullQuery(this._ensurableOption)
       this.filter({ inputType: "hw:lockInSelection" })
     }
 

--- a/app/assets/javascripts/hw_combobox/models/combobox/selection.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/selection.js
@@ -25,7 +25,7 @@ Combobox.Selection = Base => class extends Base {
   _select(option, autocompleteStrategy) {
     const previousValue = this._value
 
-    this._resetOptions()
+    this._resetOptionsSilently()
 
     autocompleteStrategy(option)
 
@@ -40,7 +40,7 @@ Combobox.Selection = Base => class extends Base {
   _selectNew() {
     const previousValue = this._value
 
-    this._resetOptions()
+    this._resetOptionsSilently()
     this._setValue(this._fullQuery)
     this._setName(this.nameWhenNewValue)
     this._markValid()
@@ -56,6 +56,12 @@ Combobox.Selection = Base => class extends Base {
 
     this._setValue(null)
     this._setActiveDescendant("")
+
+    return previousValue
+  }
+
+  _deselectAndNotify() {
+    const previousValue = this._deselect()
     this._dispatchSelectionEvent({ isNewAndAllowed: false, previousValue: previousValue })
   }
 

--- a/app/assets/javascripts/hw_combobox/models/combobox/toggle.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/toggle.js
@@ -9,7 +9,10 @@ Combobox.Toggle = Base => class extends Base {
   close() {
     if (this._isOpen) {
       this._lockInSelection()
+      this._clearInvalidQuery()
+
       this.expandedValue = false
+
       this._dispatchClosedEvent()
     }
   }
@@ -79,6 +82,8 @@ Combobox.Toggle = Base => class extends Base {
     this._actingCombobox.setAttribute("aria-expanded", true) // needs to happen after setting acting combobox
   }
 
+  // +._collapse()+ differs from `.close()` in that it might be called by stimulus on connect because
+  // it interprets a change in `expandedValue` — whereas `.close()` is only called internally by us.
   _collapse() {
     this._actingCombobox.setAttribute("aria-expanded", false) // needs to happen before resetting acting combobox
 
@@ -117,6 +122,13 @@ Combobox.Toggle = Base => class extends Base {
 
   _restoreBodyScroll() {
     enableBodyScroll(this.dialogListboxTarget)
+  }
+
+  _clearInvalidQuery() {
+    if (this._isUnjustifiablyBlank) {
+      this._deselect()
+      this._clearQuery()
+    }
   }
 
   get _isOpen() {

--- a/app/assets/javascripts/hw_combobox/models/combobox/validity.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/validity.js
@@ -34,7 +34,7 @@ Combobox.Validity = Base => class extends Base {
   // +_valueIsInvalid+ only checks if `comboboxTarget` (and not `_actingCombobox`) is required
   // because the `required` attribute is only forwarded to the `comboboxTarget` element
   get _valueIsInvalid() {
-    const isRequiredAndEmpty = this.comboboxTarget.required && !this.hiddenFieldTarget.value
+    const isRequiredAndEmpty = this.comboboxTarget.required && !this._value
     return isRequiredAndEmpty
   }
 }

--- a/app/presenters/hotwire_combobox/component.rb
+++ b/app/presenters/hotwire_combobox/component.rb
@@ -266,7 +266,7 @@ class HotwireCombobox::Component
       combobox_attrs.fetch(:data, {}).merge \
         action: "
           focus->hw-combobox#open
-          input->hw-combobox#filter
+          input->hw-combobox#filterAndSelect
           keydown->hw-combobox#navigate
           click@window->hw-combobox#closeOnClickOutside
           focusin@window->hw-combobox#closeOnFocusOutside
@@ -316,7 +316,7 @@ class HotwireCombobox::Component
     def dialog_input_data
       {
         action: "
-          input->hw-combobox#filter
+          input->hw-combobox#filterAndSelect
           keydown->hw-combobox#navigate
           click@window->hw-combobox#closeOnClickOutside".squish,
         hw_combobox_target: "dialogCombobox"

--- a/test/dummy/app/javascript/controllers/combobox/events_controller.js
+++ b/test/dummy/app/javascript/controllers/combobox/events_controller.js
@@ -27,8 +27,9 @@ export default class extends Controller {
       display: ${cast(event.detail.display) || "<empty>"}
       query: ${cast(event.detail.query) || "<empty>"}
       fieldName: ${cast(event.detail.fieldName) || "<empty>"}
-      isNew: ${cast(event.detail.isNew) || "<empty>"}
+      isNewAndAllowed: ${cast(event.detail.isNewAndAllowed) || "<empty>"}
       isValid: ${cast(event.detail.isValid) || "<empty>"}
+      previousValue: ${cast(event.detail.previousValue) || "<empty>"}
     `
   }
 }

--- a/test/dummy/app/javascript/controllers/combobox/events_controller.js
+++ b/test/dummy/app/javascript/controllers/combobox/events_controller.js
@@ -1,18 +1,24 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = [ "selectionScratchpad", "closedScratchpad" ]
+  static targets = [ "selectionScratchpad", "selectionCount", "closedScratchpad", "closedCount" ]
 
   connect() {
     this.selectionScratchpadTarget.innerText = "Ready to listen for hw-combobox events!"
   }
 
   showSelection(event) {
+    this.selectionCount ??= 0
+    this.selectionCount++
     this.selectionScratchpadTarget.innerText = this.#template(event)
+    this.selectionCountTarget.innerText = `selections: ${this.selectionCount}.`
   }
 
   showClosed(event) {
+    this.closedCount ??= 0
+    this.closedCount++
     this.closedScratchpadTarget.innerText = this.#template(event)
+    this.closedCountTarget.innerText = `closings: ${this.closedCount}.`
   }
 
   #template(event) {

--- a/test/dummy/app/views/comboboxes/custom_events.html.erb
+++ b/test/dummy/app/views/comboboxes/custom_events.html.erb
@@ -1,7 +1,20 @@
-<div data-controller="combobox--events" style="display: flex; align-items: start; gap: 1rem;">
-  <%= combobox_tag :movie, movies_path, id: "allow-new", placeholder: "allow-new", name_when_new: :new_movie, data: { action: "hw-combobox:selection->combobox--events#showSelection hw-combobox:closed->combobox--events#showClosed" } %>
-  <%= combobox_tag :movie, movies_path, id: "required", placeholder: "required", required: true, data: { action: "hw-combobox:selection->combobox--events#showSelection" } %>
+<style>
+  #required { width: 12.5rem; }
+</style>
 
-  <span data-combobox--events-target="selectionScratchpad"></span>
-  <span data-combobox--events-target="closedScratchpad"></span>
+<div data-controller="combobox--events" style="display: flex; flex-direction: column; align-items: start; gap: 1rem;">
+  <div style="display: flex; align-items: start; gap: 1rem;">
+    <span data-combobox--events-target="selectionScratchpad"></span>
+    <span data-combobox--events-target="closedScratchpad"></span>
+  </div>
+
+  <div style="display: flex; align-items: start; gap: 1rem;">
+    <div data-combobox--events-target="selectionCount"></div>
+    <div data-combobox--events-target="closedCount"></div>
+  </div>
+
+  <div style="display: flex; align-items: start; gap: 1rem;">
+    <%= combobox_tag :movie, movies_path, id: "allow-new", placeholder: "allow-new", name_when_new: :new_movie, data: { action: "hw-combobox:selection->combobox--events#showSelection hw-combobox:closed->combobox--events#showClosed" } %>
+    <%= combobox_tag :movie, movies_path, id: "required", placeholder: "required", required: true, data: { action: "hw-combobox:selection->combobox--events#showSelection hw-combobox:closed->combobox--events#showClosed" } %>
+  </div>
 </div>

--- a/test/system/hotwire_combobox_test.rb
+++ b/test/system/hotwire_combobox_test.rb
@@ -302,6 +302,7 @@ class HotwireComboboxTest < ApplicationSystemTestCase
     assert_not_invalid_combobox
     type_in_combobox "#state-field", "foobar", :enter
     assert_invalid_combobox
+    assert_combobox_display_and_value "#state-field", nil, nil
   end
 
   test "combobox is not invalid if empty but not required" do

--- a/test/system/hotwire_combobox_test.rb
+++ b/test/system/hotwire_combobox_test.rb
@@ -622,9 +622,12 @@ class HotwireComboboxTest < ApplicationSystemTestCase
 
     assert_text "Ready to listen for hw-combobox events!"
 
+    assert_no_text "selections:"
+
     open_combobox "#allow-new"
     type_in_combobox "#allow-new", "A Bea"
 
+    assert_text "selections: 1."
     assert_text "event: hw-combobox:selection"
     assert_text "value: #{movies(:a_beautiful_mind).id}"
     assert_text "display: A Beautiful Mind"
@@ -638,6 +641,7 @@ class HotwireComboboxTest < ApplicationSystemTestCase
 
     type_in_combobox "#allow-new", "t"
 
+    assert_text "selections: 2."
     assert_text "event: hw-combobox:selection"
     assert_text "value: A Beat"
     assert_text "display: A Beat"
@@ -647,10 +651,12 @@ class HotwireComboboxTest < ApplicationSystemTestCase
     assert_text "isValid: true"
     assert_text "previousValue: #{movies(:a_beautiful_mind).id}"
 
+    assert_no_text "closings:"
     assert_no_text "event: hw-combobox:closed"
 
     click_away
 
+    assert_text "closings: 1."
     assert_text "event: hw-combobox:closed"
     assert_text "value: A Beat"
     assert_text "display: A Beat"
@@ -659,8 +665,10 @@ class HotwireComboboxTest < ApplicationSystemTestCase
     assert_text "isNewAndAllowed: <empty>"
     assert_text "isValid: true"
 
+    open_combobox "#required"
     type_in_combobox "#required", "A Bea"
 
+    assert_text "selections: 3."
     assert_text "event: hw-combobox:selection"
     assert_text "value: #{movies(:a_beautiful_mind).id}"
     assert_text "display: A Beautiful Mind"
@@ -672,6 +680,7 @@ class HotwireComboboxTest < ApplicationSystemTestCase
 
     type_in_combobox "#required", "t"
 
+    assert_text "selections: 4."
     assert_text "event: hw-combobox:selection"
     assert_text "value: <empty>"
     assert_text "display: A Beat"
@@ -683,6 +692,7 @@ class HotwireComboboxTest < ApplicationSystemTestCase
 
     click_away
 
+    assert_text "closings: 2."
     assert_text "event: hw-combobox:closed"
     assert_text "value: <empty>"
     assert_text "display: A Beat"
@@ -690,6 +700,16 @@ class HotwireComboboxTest < ApplicationSystemTestCase
     assert_text "fieldName: movie"
     assert_text "isNewAndAllowed: false"
     assert_text "isValid: false"
+
+    open_combobox "#required"
+    type_in_combobox "#required", "The Godfather"
+    click_on_option "The Godfather Part II"
+    open_combobox "#required"
+    click_on_option "The Godfather Part III"
+
+    assert_text "previousValue: #{movies(:the_godfather_part_ii).id}"
+    assert_text "selections: 6."
+    assert_text "closings: 4."
   end
 
   test "customized elements" do

--- a/test/system/hotwire_combobox_test.rb
+++ b/test/system/hotwire_combobox_test.rb
@@ -629,8 +629,9 @@ class HotwireComboboxTest < ApplicationSystemTestCase
     assert_text "display: A Beautiful Mind"
     assert_text "query: A Bea"
     assert_text "fieldName: movie"
-    assert_text "isNew: false"
+    assert_text "isNewAndAllowed: false"
     assert_text "isValid: true"
+    assert_text "previousValue: <empty>"
 
     assert_no_text "event: hw-combobox:closed"
 
@@ -641,28 +642,20 @@ class HotwireComboboxTest < ApplicationSystemTestCase
     assert_text "display: A Beat"
     assert_text "query: A Beat"
     assert_text "fieldName: new_movie"
-    assert_text "isNew: true"
+    assert_text "isNewAndAllowed: true"
     assert_text "isValid: true"
+    assert_text "previousValue: #{movies(:a_beautiful_mind).id}"
 
     assert_no_text "event: hw-combobox:closed"
 
     click_away
-
-    # No changes
-    assert_text "event: hw-combobox:selection"
-    assert_text "value: A Beat"
-    assert_text "display: A Beat"
-    assert_text "query: A Beat"
-    assert_text "fieldName: new_movie"
-    assert_text "isNew: true"
-    assert_text "isValid: true"
 
     assert_text "event: hw-combobox:closed"
     assert_text "value: A Beat"
     assert_text "display: A Beat"
     assert_text "query: A Beat"
     assert_text "fieldName: new_movie"
-    assert_text "isNew: <empty>"
+    assert_text "isNewAndAllowed: <empty>"
     assert_text "isValid: true"
 
     type_in_combobox "#required", "A Bea"
@@ -672,8 +665,9 @@ class HotwireComboboxTest < ApplicationSystemTestCase
     assert_text "display: A Beautiful Mind"
     assert_text "query: A Bea"
     assert_text "fieldName: movie"
-    assert_text "isNew: false"
+    assert_text "isNewAndAllowed: false"
     assert_text "isValid: true"
+    assert_text "previousValue: <empty>"
 
     type_in_combobox "#required", "t"
 
@@ -682,17 +676,18 @@ class HotwireComboboxTest < ApplicationSystemTestCase
     assert_text "display: A Beat"
     assert_text "query: A Beat"
     assert_text "fieldName: movie"
-    assert_text "isNew: false"
+    assert_text "isNewAndAllowed: false"
     assert_text "isValid: false"
+    assert_text "previousValue: #{movies(:a_beautiful_mind).id}"
 
     click_away
 
-    assert_text "event: hw-combobox:selection"
+    assert_text "event: hw-combobox:closed"
     assert_text "value: <empty>"
-    assert_text "display: <empty>"
-    assert_text "query: <empty>"
+    assert_text "display: A Beat"
+    assert_text "query: A Beat"
     assert_text "fieldName: movie"
-    assert_text "isNew: false"
+    assert_text "isNewAndAllowed: false"
     assert_text "isValid: false"
   end
 


### PR DESCRIPTION
This is a refactor with some minor breaking changes:

* `hw-combobox:selection` is only emitted when the value changes
* In the `hw-combobox:selection` detail, `isNew` is now called `isNewAndAllowed` to better explain why the value would be `false` even if it's not in the listed options
* `previousValue` is now included in the `hw-combobox:selection` detail.

One big win from this refactor is that previously a selection might have emitted many events as the library did some internal processing. Now, only one event is emitted where you'd only expect one event.