### PR TITLE
Add background color to group label

### DIFF
--- a/app/assets/stylesheets/hotwire_combobox.css
+++ b/app/assets/stylesheets/hotwire_combobox.css
@@ -2,6 +2,7 @@
   --hw-active-bg-color: #F3F4F6;
   --hw-border-color: #D1D5DB;
   --hw-group-color: #57595C;
+  --hw-group-bg-color: #FFFFFF;
   --hw-invalid-color: #EF4444;
   --hw-dialog-label-color: #1D1D1D;
   --hw-focus-color: #2563EB;
@@ -145,6 +146,7 @@
 }
 
 .hw-combobox__group__label {
+  background-color: var(--hw-group-bg-color);
   color: var(--hw-group-color);
   padding: var(--hw-padding--slim);
 }


### PR DESCRIPTION
Add a background color to `.hw-combobox__group__label` following `.hw-combobox__option` style.

I wonder if it's worth adding the background color to `.hw-combobox__listbox` like Bootstrap does.
https://github.com/twbs/bootstrap/blob/v5.3.3/scss/_dropdown.scss#L59