### PR TITLE
Pass in query params to default async src

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,6 +139,8 @@ GEM
     minitest (5.22.2)
     minitest-focus (1.4.0)
       minitest (>= 4, < 6)
+    mocha (2.1.0)
+      ruby2_keywords (>= 0.0.5)
     mutex_m (0.2.0)
     net-imap (0.4.10)
       date
@@ -302,6 +304,7 @@ DEPENDENCIES
   hotwire_combobox!
   importmap-rails
   minitest-focus
+  mocha (~> 2.1)
   propshaft
   puma
   rubocop-37signals

--- a/app/views/hotwire_combobox/_next_page.turbo_stream.erb
+++ b/app/views/hotwire_combobox/_next_page.turbo_stream.erb
@@ -1,6 +1,6 @@
-<%# locals: (for_id:, next_page:, src:) -%>
+<%# locals: (for_id:, src:) -%>
 
 <%= turbo_stream.remove hw_pagination_frame_wrapper_id(for_id) %>
 <%= turbo_stream.append hw_listbox_id(for_id) do %>
-  <%= render "hotwire_combobox/pagination", for_id: for_id, src: hw_combobox_next_page_uri(src, next_page, for_id) %>
+  <%= render "hotwire_combobox/pagination", for_id: for_id, src: src %>
 <% end %>

--- a/hotwire_combobox.gemspec
+++ b/hotwire_combobox.gemspec
@@ -23,4 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rails", ">= 7.0.7.2"
   spec.add_dependency "stimulus-rails", ">= 1.2"
   spec.add_dependency "turbo-rails", ">= 1.2"
+
+  spec.add_development_dependency "mocha", "~> 2.1"
 end

--- a/lib/hotwire_combobox/helper.rb
+++ b/lib/hotwire_combobox/helper.rb
@@ -49,7 +49,7 @@ module HotwireCombobox
       include_blank = params[:page].to_i > 0 ? nil : include_blank
       options = hw_combobox_options options, render_in: render_in, include_blank: include_blank, **custom_methods
       this_page = render "hotwire_combobox/paginated_options", for_id: for_id, options: options
-      next_page = render "hotwire_combobox/next_page", for_id: for_id, src: src, next_page: next_page
+      next_page = render "hotwire_combobox/next_page", for_id: for_id, src: hw_combobox_next_page_uri(src, next_page, for_id)
 
       safe_join [ this_page, next_page ]
     end
@@ -150,23 +150,13 @@ module HotwireCombobox
         "#{id}__hw_combobox_pagination"
       end
 
-      def hw_combobox_next_page_uri(uri, next_page, for_id)
-        if next_page
-          hw_uri_with_params uri,
-            page: next_page,
-            q: params[:q],
-            for_id: for_id,
-            format: :turbo_stream
-        end
-      end
-
       def hw_combobox_page_stream_action
         params[:page].to_i > 0 ? :append : :update
       end
 
       def hw_uri_with_params(url_or_path, **params)
         URI.parse(url_or_path).tap do |url_or_path|
-          query = URI.decode_www_form(url_or_path.query || "").to_h.merge(params.stringify_keys)
+          query = URI.decode_www_form(url_or_path.query || "").to_h.merge(params.compact_blank.stringify_keys)
           url_or_path.query = URI.encode_www_form query
         end.to_s
       rescue URI::InvalidURIError
@@ -182,6 +172,16 @@ module HotwireCombobox
       end
 
     private
+      def hw_combobox_next_page_uri(uri, next_page, for_id)
+        return unless next_page
+
+        hw_uri_with_params uri,
+          page: next_page,
+          q: params[:q],
+          for_id: for_id,
+          format: :turbo_stream
+      end
+
       def hw_extract_options_and_src(options_or_src, render_in, include_blank)
         if options_or_src.is_a? String
           [ [], options_or_src ]

--- a/lib/hotwire_combobox/helper.rb
+++ b/lib/hotwire_combobox/helper.rb
@@ -41,7 +41,7 @@ module HotwireCombobox
     def hw_paginated_combobox_options(
           options,
           for_id: params[:for_id],
-          src: request.path,
+          src: request.fullpath,
           next_page: nil,
           render_in: {},
           include_blank: {},
@@ -166,7 +166,7 @@ module HotwireCombobox
 
       def hw_uri_with_params(url_or_path, **params)
         URI.parse(url_or_path).tap do |url_or_path|
-          query = URI.decode_www_form(url_or_path.query || "").to_h.merge(params)
+          query = URI.decode_www_form(url_or_path.query || "").to_h.merge(params.stringify_keys)
           url_or_path.query = URI.encode_www_form query
         end.to_s
       rescue URI::InvalidURIError

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,3 +1,8 @@
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   driven_by :selenium, using: :headless_chrome
+
+  def states(...)
+    # https://github.com/freerange/mocha/issues/620
+    access_fixture("states", ...)
+  end
 end

--- a/test/application_view_test_case.rb
+++ b/test/application_view_test_case.rb
@@ -14,11 +14,11 @@ class ApplicationViewTestCase < ActionView::TestCase
     def escaped_attrs(attrs)
       attrs.map do |k, v|
         %Q(#{escape_specials(k)}="#{escape_specials(v)}".*)
-      end.join(" ")
+      end.join(" ").gsub("&", "&amp;")
     end
 
     def escape_specials(value)
-      special_characters = Regexp.union "[]".chars
+      special_characters = Regexp.union "[]?".chars
       value.to_s.gsub(special_characters) { |char| "\\#{char}" }
     end
 end

--- a/test/helpers/hotwire_combobox/helper_test.rb
+++ b/test/helpers/hotwire_combobox/helper_test.rb
@@ -120,4 +120,17 @@ class HotwireCombobox::HelperTest < ApplicationViewTestCase
       combobox_tag :foo, multiselect_chip_src: "some_path", name_when_new: :foo
     end
   end
+
+  test "hw_combobox_next_page_uri updates URI with pagination params while preserving other parameters" do
+    uri         = "/foo"
+    complex_uri = "#{uri}?exclude_id=5&page=1&q=&for_id=movie_id&format=turbo_stream"
+    next_page   = 2
+    for_id      = "movie_id"
+
+    expected_next_page_uri = "#{uri}?page=#{next_page}&q&for_id=#{for_id}&format=turbo_stream"
+    assert_equal expected_next_page_uri, hw_combobox_next_page_uri(uri, next_page, for_id)
+
+    expected_next_page_uri = "#{uri}?exclude_id=5&page=#{next_page}&q&for_id=#{for_id}&format=turbo_stream"
+    assert_equal expected_next_page_uri, hw_combobox_next_page_uri(complex_uri, next_page, for_id)
+  end
 end

--- a/test/helpers/hotwire_combobox/helper_test.rb
+++ b/test/helpers/hotwire_combobox/helper_test.rb
@@ -121,16 +121,11 @@ class HotwireCombobox::HelperTest < ApplicationViewTestCase
     end
   end
 
-  test "hw_combobox_next_page_uri updates URI with pagination params while preserving other parameters" do
-    uri         = "/foo"
-    complex_uri = "#{uri}?exclude_id=5&page=1&q=&for_id=movie_id&format=turbo_stream"
-    next_page   = 2
-    for_id      = "movie_id"
+  test "hw_paginated_combobox_options includes existing params in the default next page src" do
+    request.expects(:fullpath).returns "/foo?bar=baz&qux=quux&page=1000"
 
-    expected_next_page_uri = "#{uri}?page=#{next_page}&q&for_id=#{for_id}&format=turbo_stream"
-    assert_equal expected_next_page_uri, hw_combobox_next_page_uri(uri, next_page, for_id)
+    html = hw_paginated_combobox_options [], next_page: 2
 
-    expected_next_page_uri = "#{uri}?exclude_id=5&page=#{next_page}&q&for_id=#{for_id}&format=turbo_stream"
-    assert_equal expected_next_page_uri, hw_combobox_next_page_uri(complex_uri, next_page, for_id)
+    assert_attrs html, tag_name: "turbo-frame", src: "/foo?bar=baz&qux=quux&page=2&format=turbo_stream"
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,6 +5,7 @@ require_relative "../test/dummy/config/environment"
 ActiveRecord::Migrator.migrations_paths = [ File.expand_path("../test/dummy/db/migrate", __dir__) ]
 ActiveRecord::Migrator.migrations_paths << File.expand_path("../db/migrate", __dir__)
 require "rails/test_help"
+require "mocha/minitest"
 
 # Load fixtures from the engine
 if ActiveSupport::TestCase.respond_to?(:fixture_paths=)


### PR DESCRIPTION
Before, default `src` was set using `request.path` which returns virtual path without query string.

This PR changes default implementation to use `request.fullpath` which returns virtual path with query string.

Form example; In our app we have one controller endpoint where we filter the results not just base on user entry `q` but also query strings.