### PR TITLE
Enable stimulus debug mode for development

### DIFF
--- a/test/dummy/app/javascript/controllers/application.js
+++ b/test/dummy/app/javascript/controllers/application.js
@@ -3,7 +3,7 @@ import { Application } from "@hotwired/stimulus"
 const application = Application.start()
 
 // Configure Stimulus development experience
-application.debug = false
+application.debug = true
 window.Stimulus   = application
 
 export { application }


### PR DESCRIPTION
Enabling Stimulus debug mode is helpful to figure out how everything ties in on the JS side