### PR TITLE
Enums issue with the form

### DIFF
--- a/app/presenters/hotwire_combobox/component.rb
+++ b/app/presenters/hotwire_combobox/component.rb
@@ -301,8 +301,7 @@ class HotwireCombobox::Component
       return value if value
 
       if form_object&.try(:defined_enums)&.try(:[], name)
-        # form_object.public_send "#{name}_before_type_cast"
-        form_object.public_send name
+        form_object.public_send "#{name}_before_type_cast"
       else
         form_object&.try(name).then do |value|
           value.respond_to?(:map) ? value.join(",") : value

--- a/app/presenters/hotwire_combobox/component.rb
+++ b/app/presenters/hotwire_combobox/component.rb
@@ -301,7 +301,8 @@ class HotwireCombobox::Component
       return value if value
 
       if form_object&.try(:defined_enums)&.try(:[], name)
-        form_object.public_send "#{name}_before_type_cast"
+        # form_object.public_send "#{name}_before_type_cast"
+        form_object.public_send name
       else
         form_object&.try(name).then do |value|
           value.respond_to?(:map) ? value.join(",") : value

--- a/test/dummy/app/controllers/movies_controller.rb
+++ b/test/dummy/app/controllers/movies_controller.rb
@@ -13,9 +13,25 @@ class MoviesController < ApplicationController
   def index_with_blank_html
   end
 
+  def update
+    @movie = Movie.find(params[:id])
+
+    respond_to do |format|
+      if @movie.update(movie_params)
+        format.html { redirect_to enum_url, notice: "Movie was successfully updated." }
+      else
+        format.html { render :edit, status: :unprocessable_entity }
+      end
+    end
+  end
+
   private
     def set_page
       movies = params[:full_search] ? Movie.full_search(params[:q]) : Movie.search(params[:q])
       set_page_and_extract_portion_from movies.alphabetically, per_page: 5
+    end
+
+    def movie_params
+      params.require(:movie).permit(:title, :rating)
     end
 end

--- a/test/dummy/app/views/comboboxes/enum.html.erb
+++ b/test/dummy/app/views/comboboxes/enum.html.erb
@@ -1,5 +1,6 @@
 <%= form_with model: Movie.first do |form| %>
   <%= form.combobox :rating, Movie.ratings %>
+  <%= form.submit %>
 <% end %>
 
 <%= combobox_tag "rating-enum", Movie.ratings, id: "rating-enum" %>

--- a/test/dummy/app/views/comboboxes/enum.html.erb
+++ b/test/dummy/app/views/comboboxes/enum.html.erb
@@ -1,4 +1,5 @@
 <%= form_with model: Movie.first do |form| %>
+  <%#= form.combobox :rating, Movie.ratings.keys %>
   <%= form.combobox :rating, Movie.ratings %>
   <%= form.submit %>
 <% end %>

--- a/test/system/hotwire_combobox_test.rb
+++ b/test/system/hotwire_combobox_test.rb
@@ -574,6 +574,20 @@ class HotwireComboboxTest < ApplicationSystemTestCase
     click_away
   end
 
+  test "enum combobox with form" do
+    Movie.update_all rating: :PG
+
+    visit enum_path
+
+    assert_combobox_display_and_value "#movie_rating", "PG", Movie.ratings[:PG]
+
+    open_combobox "#rating-enum"
+    click_on_option "R"
+
+    click_on "Update Movie"
+    assert_combobox_display_and_value "#movie_rating", "R", Movie.ratings[:R]
+  end
+
   test "async autocomplete selections don't trample over each other" do
     visit async_path
 

--- a/test/system/hotwire_combobox_test.rb
+++ b/test/system/hotwire_combobox_test.rb
@@ -580,8 +580,6 @@ class HotwireComboboxTest < ApplicationSystemTestCase
     open_combobox "#movie_rating"
     click_on_option "R"
     click_on "Update Movie"
-
-    assert_combobox_display_and_value "#movie_rating", "R", Movie.ratings[:R]
   end
 
   test "async autocomplete selections don't trample over each other" do

--- a/test/system/hotwire_combobox_test.rb
+++ b/test/system/hotwire_combobox_test.rb
@@ -575,16 +575,12 @@ class HotwireComboboxTest < ApplicationSystemTestCase
   end
 
   test "enum combobox with form" do
-    Movie.update_all rating: :PG
-
     visit enum_path
 
-    assert_combobox_display_and_value "#movie_rating", "PG", Movie.ratings[:PG]
-
-    open_combobox "#rating-enum"
+    open_combobox "#movie_rating"
     click_on_option "R"
-
     click_on "Update Movie"
+
     assert_combobox_display_and_value "#movie_rating", "R", Movie.ratings[:R]
   end
 


### PR DESCRIPTION
This PR is opened just to describe the issue with enums and forms;

If we follow official documentation or repos showcase page we have
`form.combobox :rating, Movie.ratings`

This style will work only if enum key and value are same (string) for example:
```ruby
class Movie < ApplicationRecord
   enum rating: %w[ G PG PG-13 R NC-17 ].index_by(&:itself)
end
```

If we use default rails enum approach where enum value is stored as an integer inside the db column, this will not work, Rails will fail to set the enum value and raise an exception: `ArgumentError: '3' is not a valid rating`

I've added te system test just to confirm this issue.

In order to make this work for default enum approach we would need to use `#keys` on the enum to pass the enum keys,
like this

```erb
<%= form.combobox :rating, Movie.ratings.keys %>
```

----------------

I don't think this is engines fault, but maybe(just maybe) this needs to be documented, or at least we should change examples in the showcase page to show the valid state;

[This `<%= form.combobox :rating, Movie.ratings.keys %>`](https://github.com/josefarias/hotwire_combobox/compare/main...dixpac:dix/enum_issue?expand=1#diff-0de720a8f8eb38de1b9f01a6f3246225fb74685056f4d94aba89e30e963c6802R2)

instead of this
`<%= form.combobox :rating, Movie.ratings %>`



