### PR TITLE
Strip transient params from default async pagination src

### DIFF
--- a/lib/hotwire_combobox/helper.rb
+++ b/lib/hotwire_combobox/helper.rb
@@ -37,7 +37,7 @@ module HotwireCombobox
     def hw_paginated_combobox_options(
           options,
           for_id: params[:for_id],
-          src: request.fullpath,
+          src: hw_fullpath_for_pagination,
           next_page: nil,
           render_in: {},
           include_blank: {},
@@ -168,6 +168,11 @@ module HotwireCombobox
       end
 
     private
+      def hw_fullpath_for_pagination
+        transient_params = %w[ input_type ]
+        hw_uri_with_params request.path, **request.query_parameters.except(*transient_params)
+      end
+
       def hw_combobox_next_page_uri(uri, next_page, for_id)
         return unless next_page
 

--- a/test/helpers/hotwire_combobox/helper_test.rb
+++ b/test/helpers/hotwire_combobox/helper_test.rb
@@ -121,8 +121,9 @@ class HotwireCombobox::HelperTest < ApplicationViewTestCase
     end
   end
 
-  test "hw_paginated_combobox_options includes existing params in the default next page src" do
-    request.expects(:fullpath).returns "/foo?bar=baz&qux=quux&page=1000"
+  test "hw_paginated_combobox_options includes existing params in the default next page src, but excludes transient params" do
+    request.expects(:path).returns("/foo")
+    request.expects(:query_parameters).returns({ bar: "baz", qux: "quux", page: "1000", input_type: "insertText" }.with_indifferent_access)
 
     html = hw_paginated_combobox_options [], next_page: 2
 

--- a/test/system/hotwire_combobox_test.rb
+++ b/test/system/hotwire_combobox_test.rb
@@ -537,6 +537,12 @@ class HotwireComboboxTest < ApplicationSystemTestCase
       assert_options_with count: test_case[:visible_options]
       find("#movie-field-hw-listbox").scroll_to :bottom
       assert_options_with count: test_case[:visible_options] + 5
+
+      type_in_combobox "#movie-field", "a"
+      assert_combobox_display_and_value "#movie-field", "A Beautiful Mind", movies(:a_beautiful_mind).id
+      find("#movie-field-hw-listbox").scroll_to :bottom
+      assert_options_with count: test_case[:visible_options] + 5
+      assert_scrolled "#movie-field-hw-listbox"
     end
   end
 
@@ -1285,6 +1291,12 @@ class HotwireComboboxTest < ApplicationSystemTestCase
 
     def assert_group_with(**kwargs)
       assert_selector "ul[role=group] li[role=presentation]", **kwargs
+    end
+
+    def assert_scrolled(selector)
+      sleep 0.5
+      assert page.evaluate_script("document.querySelector('#{selector}').scrollTop") > 0,
+        "Expected #{selector} to be scrolled."
     end
 
     def remove_chip(text)


### PR DESCRIPTION
Closes https://github.com/josefarias/hotwire_combobox/issues/159