### PR TITLE
Add `:free_text` as a shorthand for `:name_when_new` with same name

### DIFF
--- a/app/presenters/hotwire_combobox/component.rb
+++ b/app/presenters/hotwire_combobox/component.rb
@@ -16,6 +16,7 @@ class HotwireCombobox::Component
         data:                 {},
         dialog_label:         nil,
         form:                 nil,
+        free_text:            false,
         id:                   nil,
         input:                {},
         label:                nil,
@@ -26,9 +27,9 @@ class HotwireCombobox::Component
         options:              [],
         value:                nil,
         **rest
-    @view, @autocomplete, @id, @name, @value, @form, @async_src, @label,
+    @view, @autocomplete, @id, @name, @value, @form, @async_src, @label, @free_text,
     @name_when_new, @open, @data, @mobile_at, @multiselect_chip_src, @options, @dialog_label =
-      view, autocomplete, id, name.to_s, value, form, async_src, label,
+      view, autocomplete, id, name.to_s, value, form, async_src, label, free_text,
       name_when_new, open, data, mobile_at, multiselect_chip_src, options, dialog_label
 
     @combobox_attrs = input.reverse_merge(rest).deep_symbolize_keys
@@ -189,8 +190,16 @@ class HotwireCombobox::Component
 
   private
     attr_reader :view, :autocomplete, :id, :name, :value, :form,
-      :name_when_new, :open, :data, :combobox_attrs, :mobile_at,
+      :free_text, :open, :data, :combobox_attrs, :mobile_at,
       :association_name, :multiselect_chip_src
+
+    def name_when_new
+      if free_text && @name_when_new.blank?
+        hidden_field_name
+      else
+        @name_when_new
+      end
+    end
 
     def name_when_new_on_multiselect_must_match_original_name
       return unless multiselect? && name_when_new.present?

--- a/test/dummy/app/views/comboboxes/multiselect_new_values.html.erb
+++ b/test/dummy/app/views/comboboxes/multiselect_new_values.html.erb
@@ -1,13 +1,25 @@
+<%= tag.style nonce: content_security_policy_nonce do %>
+  form {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  input[type="submit"] {
+    padding: 0.5rem;
+  }
+<% end %>
+
 <% if flash[:notice] %>
   <p><%= flash[:notice] %></p>
 <% end %>
 
-<%= form_with model: @user, url: user_visits_url(@user), method: :post, html: { style: "display: flex; flex-direction: column; gap: 1rem;" } do |form| %>
+<%= form_with model: @user, url: user_visits_url(@user), method: :post do |form| %>
   <%= combobox_tag "user[visited_states]",
         State.all,
         id: "states-field",
         label: "Visited states (new allowed)",
         multiselect_chip_src: possibly_new_state_chips_path,
-        name_when_new: "user[visited_states]" %>
-  <%= form.submit style: "padding: 0.5rem;" %>
+        free_text: true %>
+  <%= form.submit %>
 <% end %>

--- a/test/dummy/app/views/comboboxes/multiselect_prefilled_form.html.erb
+++ b/test/dummy/app/views/comboboxes/multiselect_prefilled_form.html.erb
@@ -1,8 +1,20 @@
+<%= tag.style nonce: content_security_policy_nonce do %>
+  form {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  input[type="submit"] {
+    padding: 0.5rem;
+  }
+<% end %>
+
 <% if flash[:notice] %>
   <p><%= flash[:notice] %></p>
 <% end %>
 
-<%= form_with model: @user, html: { style: "display: flex; flex-direction: column; gap: 1rem;" } do |form| %>
+<%= form_with model: @user do |form| %>
   <%= form.combobox :visited_state_ids, State.all, label: "Visited states", multiselect_chip_src: state_chips_path %>
-  <%= form.submit style: "padding: 0.5rem;" %>
+  <%= form.submit %>
 <% end %>

--- a/test/dummy/app/views/comboboxes/new_options.html.erb
+++ b/test/dummy/app/views/comboboxes/new_options.html.erb
@@ -16,4 +16,4 @@
   <%= form.submit %>
 <% end %>
 
-<%= combobox_tag :movie, movies_path, name_when_new: :new_movie, id: "movie-field", style: "width: 13rem;" %>
+<%= combobox_tag :movie, movies_path, name_when_new: :new_movie, id: "movie-field" %>

--- a/test/helpers/hotwire_combobox/helper_test.rb
+++ b/test/helpers/hotwire_combobox/helper_test.rb
@@ -118,7 +118,22 @@ class HotwireCombobox::HelperTest < ApplicationViewTestCase
 
     assert_nothing_raised do
       combobox_tag :foo, multiselect_chip_src: "some_path", name_when_new: :foo
+      combobox_tag :foo, multiselect_chip_src: "some_path", free_text: true
     end
+  end
+
+  test "free_text is a shortcut for name_when_new" do
+    tag = combobox_tag :foo, free_text: true
+    assert_attrs tag, tag_name: "fieldset", "data-hw-combobox-name-when-new-value": "foo"
+
+    tag = combobox_tag :foo, free_text: true, name_when_new: nil
+    assert_attrs tag, tag_name: "fieldset", "data-hw-combobox-name-when-new-value": "foo"
+
+    tag = combobox_tag :foo, free_text: true, name_when_new: :bar
+    assert_attrs tag, tag_name: "fieldset", "data-hw-combobox-name-when-new-value": "bar"
+
+    tag = combobox_tag :foo, free_text: false, name_when_new: :bar
+    assert_attrs tag, tag_name: "fieldset", "data-hw-combobox-name-when-new-value": "bar"
   end
 
   test "hw_paginated_combobox_options includes existing params in the default next page src, but excludes transient params" do


### PR DESCRIPTION
Ref https://github.com/josefarias/hotwire_combobox/discussions/127#discussioncomment-8973880

`:name_when_new` will always take precedence. See test in this PR for examples. 