### PR TITLE
Add test for name_when_new without free_text

### DIFF
--- a/test/helpers/hotwire_combobox/helper_test.rb
+++ b/test/helpers/hotwire_combobox/helper_test.rb
@@ -134,6 +134,9 @@ class HotwireCombobox::HelperTest < ApplicationViewTestCase
 
     tag = combobox_tag :foo, free_text: false, name_when_new: :bar
     assert_attrs tag, tag_name: "fieldset", "data-hw-combobox-name-when-new-value": "bar"
+
+    tag = combobox_tag :foo, name_when_new: :bar
+    assert_attrs tag, tag_name: "fieldset", "data-hw-combobox-name-when-new-value": "bar"
   end
 
   test "hw_paginated_combobox_options includes existing params in the default next page src, but excludes transient params" do


### PR DESCRIPTION
Missed this test in https://github.com/josefarias/hotwire_combobox/pull/163