### PR TITLE
Add `icon`, basically a `handle` on the left and hidden:on-load

### DIFF
--- a/app/assets/stylesheets/hotwire_combobox.css
+++ b/app/assets/stylesheets/hotwire_combobox.css
@@ -26,6 +26,10 @@
 
   --hw-font-size: 1rem;
 
+  --hw-icon-image: url("");
+  --hw-icon-offset-right: 0.375rem;
+  --hw-icon-width: 1.5rem;
+
   --hw-handle-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3E%3Cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='m6 8 4 4 4-4'/%3E%3C/svg%3E");
   --hw-handle-image--queried: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24'%3E%3Cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M6 18 18 6M6 6l12 12'/%3E%3C/svg%3E");
   --hw-handle-offset-right: 0.375rem;
@@ -76,6 +80,27 @@
   &:has(.hw-combobox__input--invalid) {
     box-shadow: 0 0 0 var(--hw-border-width--thick) var(--hw-invalid-color);
   }
+}
+
+.hw-combobox__icon {
+  height: 100%;
+  position: absolute;
+  left: var(--hw-icon-offset-right);
+  top: 0;
+  width: var(--hw-icon-width);
+}
+
+.hw-combobox__icon::before {
+  background-image: var(--hw-icon-image);
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: var(--hw-icon-width);
+  bottom: 0;
+  content: '';
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
 }
 
 .hw-combobox__input {

--- a/app/presenters/hotwire_combobox/component.rb
+++ b/app/presenters/hotwire_combobox/component.rb
@@ -88,6 +88,14 @@ class HotwireCombobox::Component
   end
 
 
+  def icon_attrs
+    apply_customizations_to :icon, base: {
+      class: "hw-combobox__icon",
+      data: icon_data
+    }
+  end
+
+
   def input_attrs
     nested_attrs = %i[ data aria ]
 
@@ -349,6 +357,13 @@ class HotwireCombobox::Component
         haspopup: "listbox",
         autocomplete: autocomplete,
         activedescendant: ""
+    end
+
+    def icon_data
+      {
+        action: "click->hw-combobox#clearOrToggleOnHandleClick",
+        hw_combobox_target: "icon"
+      }
     end
 
 

--- a/app/presenters/hotwire_combobox/component/customizable.rb
+++ b/app/presenters/hotwire_combobox/component/customizable.rb
@@ -4,6 +4,7 @@ module HotwireCombobox::Component::Customizable
     label
     hidden_field
     main_wrapper
+    icon
     input
     handle
     listbox

--- a/app/views/hotwire_combobox/combobox/_input.html.erb
+++ b/app/views/hotwire_combobox/combobox/_input.html.erb
@@ -1,2 +1,3 @@
+<%= tag.div **component.icon_attrs %>
 <%= tag.input **component.input_attrs %>
 <%= tag.span **component.handle_attrs %>

--- a/test/dummy/app/views/comboboxes/custom_attrs.html.erb
+++ b/test/dummy/app/views/comboboxes/custom_attrs.html.erb
@@ -3,6 +3,7 @@
   <% combobox.customize_label class: "custom-class--label", data: { customized_label: "" } %>
   <% combobox.customize_hidden_field class: "custom-class--hidden_field", data: { customized_hidden_field: "" } %>
   <% combobox.customize_main_wrapper class: "custom-class--main_wrapper", data: { customized_main_wrapper: "" } %>
+  <% combobox.customize_icon class: "custom-class--icon", data: { customized_icon: "" } %>
   <% combobox.customize_input class: "custom-class--input", data: { customized_input: "" } %>
   <% combobox.customize_handle class: "custom-class--handle", data: { customized_handle: "" } %>
   <% combobox.customize_listbox class: "custom-class--listbox", data: { customized_listbox: "" } %>

--- a/test/system/hotwire_combobox_test.rb
+++ b/test/system/hotwire_combobox_test.rb
@@ -746,6 +746,7 @@ class HotwireComboboxTest < ApplicationSystemTestCase
     assert_selector ".custom-class--fieldset"
     assert_selector ".custom-class--label"
     assert_selector ".custom-class--main_wrapper"
+    assert_selector ".custom-class--icon"
     assert_selector ".custom-class--input"
     assert_selector ".custom-class--handle"
     assert_selector ".custom-class--hidden_field", visible: :hidden
@@ -759,6 +760,7 @@ class HotwireComboboxTest < ApplicationSystemTestCase
     assert_selector ".hw-combobox", count: 2
     assert_selector ".hw-combobox__label", count: 2
     assert_selector ".hw-combobox__main__wrapper", count: 2
+    assert_selector ".hw-combobox__icon", count: 2
     assert_selector ".hw-combobox__input", count: 2
     assert_selector ".hw-combobox__handle", count: 2
     assert_selector ".hw-combobox__listbox", visible: :hidden, count: 2
@@ -773,6 +775,7 @@ class HotwireComboboxTest < ApplicationSystemTestCase
     assert_selector "[data-customized-fieldset]"
     assert_selector "[data-customized-label]"
     assert_selector "[data-customized-main-wrapper]"
+    assert_selector "[data-customized-icon]"
     assert_selector "[data-customized-input]"
     assert_selector "[data-customized-handle]"
     assert_selector "[data-customized-hidden-field]", visible: :hidden


### PR DESCRIPTION
My use-case is pretty simple. I just wanted to have an icon on the left.

- _app/views/*.html.erb
```erb
      <div class="hw-cb w-1/2">
        <%= form.combobox :user_card_id, @user_cards, render_in: { partial: "user_card" }, placeholder: "Card" %>
      </div>
```

- _/app/assets/stylesheets/application.tailwind.css
```css
.hw-cb {
  .hw-combobox {
    @apply w-full;
  }

  .hw-combobox__main__wrapper {
    @apply w-full;
    @apply ps-10;
    @apply py-[10px];
  }

  .hw-combobox__icon {
    @apply absolute;
    @apply inset-y-0;
    @apply start-3.5;
    @apply ps-3.5;
    @apply flex;
    @apply items-center;
  }

  .hw-combobox__handle {
    @apply right-2;
  }

  .hw-combobox__input {
    @apply ps-2;
    @apply placeholder-gray-500;
  }

  .hw-combobox__listbox { }

  .hw-combobox__option:hover,
  .hw-combobox__option--navigated,
  .hw-combobox__option--selected {
    @apply bg-slate-600;
    @apply text-white;
  }

  --hw-icon-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='currentColor' class='w-6 h-6'%3E%3Cpath d='M2.273 5.625A4.483 4.483 0 015.25 4.5h13.5c1.141 0 2.183.425 2.977 1.125A3 3 0 0018.75 3H5.25a3 3 0 00-2.977 2.625zM2.273 8.625A4.483 4.483 0 015.25 7.5h13.5c1.141 0 2.183.425 2.977 1.125A3 3 0 0018.75 6H5.25a3 3 0 00-2.977 2.625zM5.25 9a3 3 0 00-3 3v6a3 3 0 003 3h13.5a3 3 0 003-3v-6a3 3 0 00-3-3H15a.75.75 0 00-.75.75 2.25 2.25 0 01-4.5 0A.75.75 0 009 9H5.25z' /%3E%3C/svg%3E%0A");
}

```
![image](https://github.com/josefarias/hotwire_combobox/assets/36988302/0c891a4a-51fe-4de7-ad4c-2b028fbe8e20)


I wanted to mimic the render_in with a partial to the svg, but decided on just mimicking the handle.

This is my first time messing with some Open Source Code, I'm open to criticism.