### PR TITLE
Add `onchange` event when selecting on click in empty `ListBox`

### DIFF
--- a/app/assets/javascripts/hw_combobox/models/combobox/selection.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/selection.js
@@ -5,6 +5,7 @@ Combobox.Selection = Base => class extends Base {
   selectOnClick({ currentTarget, inputType }) {
     this._forceSelectionAndFilter(currentTarget, inputType)
     this._closeAndBlur("hw:optionRoleClick")
+    this._fireOnChangeEvent()
   }
 
   _connectSelection() {
@@ -139,6 +140,10 @@ Combobox.Selection = Base => class extends Base {
 
   _removeActiveDescendant() {
     this._setActiveDescendant("")
+  }
+
+  _fireOnChangeEvent() {
+    this._actingCombobox.dispatchEvent(new Event("change", { bubbles: true }))
   }
 
   get _hasValueButNoSelection() {


### PR DESCRIPTION
The `onchange` event was not being triggered when selecting from ListBox without having typed anything in the `.hw-combobox__input`.


I tried to see if the navigate/ClickOnTheOutside stimulus actions were doing something SelectOnClick wasn't, but soon I realised that the `onchange` event was being triggered only due to its nature.