### PR TITLE
open listbox only if it contains options

### DIFF
--- a/app/assets/stylesheets/hotwire_combobox.css
+++ b/app/assets/stylesheets/hotwire_combobox.css
@@ -141,6 +141,10 @@
   &:has([role="option"]:not([hidden])) {
     border-color: var(--hw-border-color);
   }
+
+  &:not(:has(.hw-combobox__option)) {
+    display: none;
+  }
 }
 
 .hw-combobox__group {


### PR DESCRIPTION
In case the listbox doesn't have any options it doesn't need to be shown.
See this discussion for reference: https://github.com/josefarias/hotwire_combobox/discussions/178