### PR TITLE
Change justify-content value to fix autoprefixer warning

### DIFF
--- a/app/assets/stylesheets/hotwire_combobox.css
+++ b/app/assets/stylesheets/hotwire_combobox.css
@@ -209,7 +209,7 @@
     align-items: center;
     display: flex;
     flex-direction: column;
-    justify-content: start;
+    justify-content: flex-start;
   }
 
   &::backdrop {


### PR DESCRIPTION
This request fixes issue https://github.com/josefarias/hotwire_combobox/issues/187

Why This Change?

- `justify-content: start` This value is part of the CSS Box Alignment Module Level 3 specification and isn't fully supported in all browsers.
- `justify-content: flex-start` This value is widely supported across modern browsers and ensures that the content is aligned at the start of the flex container.
