### PR TITLE
Fix interactivity of listbox options when combobox is in a dialog

### DIFF
--- a/app/presenters/hotwire_combobox/listbox/option.rb
+++ b/app/presenters/hotwire_combobox/listbox/option.rb
@@ -28,7 +28,8 @@ class HotwireCombobox::Listbox::Option
         role: :option,
         class: [ "hw-combobox__option", { "hw-combobox__option--blank": blank? } ],
         data: data,
-        aria: aria
+        aria: aria,
+        tabindex: -1
       }
     end
 

--- a/app/presenters/hotwire_combobox/listbox/option.rb
+++ b/app/presenters/hotwire_combobox/listbox/option.rb
@@ -26,10 +26,10 @@ class HotwireCombobox::Listbox::Option
       {
         id: id,
         role: :option,
+        tabindex: "-1",
         class: [ "hw-combobox__option", { "hw-combobox__option--blank": blank? } ],
         data: data,
-        aria: aria,
-        tabindex: -1
+        aria: aria
       }
     end
 

--- a/test/dummy/app/controllers/comboboxes_controller.rb
+++ b/test/dummy/app/controllers/comboboxes_controller.rb
@@ -106,6 +106,9 @@ class ComboboxesController < ApplicationController
     @user = User.first || raise("No user found, load fixtures first.")
   end
 
+  def dialog
+  end
+
   private
     delegate :combobox_options, :html_combobox_options, to: "ApplicationController.helpers", private: true
 

--- a/test/dummy/app/javascript/controllers/dialog_controller.js
+++ b/test/dummy/app/javascript/controllers/dialog_controller.js
@@ -1,0 +1,9 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = [ "dialog" ]
+
+  open() {
+    this.dialogTarget.showModal()
+  }
+}

--- a/test/dummy/app/views/comboboxes/dialog.html.erb
+++ b/test/dummy/app/views/comboboxes/dialog.html.erb
@@ -1,0 +1,16 @@
+<%= tag.style nonce: content_security_policy_nonce do %>
+  dialog {
+    height: 80vh;
+    width: 80vw;
+  }
+<% end %>
+
+<article data-controller="dialog">
+  <dialog data-dialog-target="dialog">
+    <%= form_with model: Movie.new do |form| %>
+      <%= form.combobox :rating, Movie.ratings %>
+    <% end %>
+  </dialog>
+
+  <button data-action="dialog#open">Show modal</button>
+</article>

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -31,6 +31,7 @@ Rails.application.routes.draw do
   get "morph", to: "comboboxes#morph"
   get "form_object", to: "comboboxes#form_object"
   get "external_clear", to: "comboboxes#external_clear"
+  get "dialog", to: "comboboxes#dialog"
 
   resources :movies, only: %i[ index update ]
   get "movies_html", to: "movies#index_html"

--- a/test/system/hotwire_combobox_test.rb
+++ b/test/system/hotwire_combobox_test.rb
@@ -1321,6 +1321,16 @@ class HotwireComboboxTest < ApplicationSystemTestCase
     page.evaluate_script("document.activeElement.id") == "external_clear"
   end
 
+  test "selecting options within a dialog" do
+    visit dialog_path
+
+    click_on "Show modal"
+
+    open_combobox "#movie_rating"
+    click_on_option "R"
+    assert_combobox_display_and_value "#movie_rating", "R", Movie.ratings[:R]
+  end
+
   private
     def open_combobox(selector)
       find(selector).click


### PR DESCRIPTION
Resolves #196

It appears that most browsers won't allow the listbox options to receive any pointer events unless they are also focusable.

We probably don't actually want the listbox options to receive focus through the tab sequence, since this would be in conflict with the combobox pattern as described by W3: https://www.w3.org/WAI/ARIA/apg/patterns/combobox/
> Note: The popup indicator icon or button (if present), the popup, and the popup descendants are excluded from the page Tab sequence.

Fortunately, it seems setting a tabindex of -1 on the options satisfies both parts.