### PR TITLE
Allow pre-filling of free text inputs

### DIFF
--- a/app/presenters/hotwire_combobox/component.rb
+++ b/app/presenters/hotwire_combobox/component.rb
@@ -246,7 +246,7 @@ class HotwireCombobox::Component
       elsif async_src && form_object&.respond_to?(name)
         form_object.public_send name
       else
-        options.find_by_value(hidden_field_value)&.autocompletable_as
+        options.find_by_value(hidden_field_value)&.autocompletable_as || hidden_field_value
       end
     end
 

--- a/test/dummy/app/controllers/comboboxes_controller.rb
+++ b/test/dummy/app/controllers/comboboxes_controller.rb
@@ -43,6 +43,9 @@ class ComboboxesController < ApplicationController
     @user = User.first || raise("No user found, load fixtures first.")
   end
 
+  def prefilled_free_text
+  end
+
   def prefilled_html
   end
 

--- a/test/dummy/app/views/comboboxes/prefilled_free_text.html.erb
+++ b/test/dummy/app/views/comboboxes/prefilled_free_text.html.erb
@@ -1,0 +1,1 @@
+<%= combobox_tag "state", @state_options, value: "East Oregon", free_text: true, id: "state-field" %>

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
   get "freetext_async", to: "comboboxes#freetext_async"
   get "prefilled_async", to: "comboboxes#prefilled_async"
   get "prefilled_form", to: "comboboxes#prefilled_form"
+  get "prefilled_free_text", to: "comboboxes#prefilled_free_text"
   get "async_html", to: "comboboxes#async_html"
   get "render_in", to: "comboboxes#render_in"
   get "enum", to: "comboboxes#enum"

--- a/test/system/hotwire_combobox_test.rb
+++ b/test/system/hotwire_combobox_test.rb
@@ -396,6 +396,17 @@ class HotwireComboboxTest < ApplicationSystemTestCase
     assert_selected_option_with text: "Michigan"
   end
 
+  test "combobox with prefilled free text value" do
+    visit prefilled_free_text_path
+
+    assert_closed_combobox
+    assert_combobox_display_and_value "#state-field", "East Oregon", "East Oregon"
+
+    open_combobox "#state-field"
+    assert_no_visible_selected_option
+    assert_option_with text: "Oregon"
+  end
+
   test "html combobox with prefilled value" do
     visit prefilled_html_path
 


### PR DESCRIPTION
This change allows free text to be re-displayed just like an id-based value from the options will be re-displayed. This allows the form to be re-painted for search applications as well as re-displaying forms after validation errors that would create a new entry.

It covers the case where the free text is returned in the same field as selected-option values. I'm not sure I see anything in the design that allows pre-filling of fields named via name_when_new, which seems fine.

I have an application for this where a search result is based on either an option selection, or a full-text search based on a free text entry, and want to be able to re-draw the form with the same text displayed.

Thanks for an inspiring and useful gem!