### PR TITLE
Show that no results are found if there are no options

### DIFF
--- a/app/assets/stylesheets/hotwire_combobox.css
+++ b/app/assets/stylesheets/hotwire_combobox.css
@@ -171,6 +171,15 @@
   border-bottom: var(--hw-border-width--slim) solid var(--hw-border-color);
 }
 
+.hw-combobox__option--no-results {
+  color: var(--hw-border-color);
+  cursor: initial;
+
+  &:hover {
+    background-color: transparent !important;
+  }
+}
+
 .hw-combobox__option:hover,
 .hw-combobox__option--navigated,
 .hw-combobox__option--selected {

--- a/app/views/hotwire_combobox/_paginated_options.turbo_stream.erb
+++ b/app/views/hotwire_combobox/_paginated_options.turbo_stream.erb
@@ -1,7 +1,13 @@
 <%# locals: (for_id:, options:) -%>
 
 <%= turbo_stream.public_send(hw_combobox_page_stream_action, hw_listbox_id(for_id)) do %>
-  <% options.each do |option| %>
-    <%= render option %>
+  <% if options.any? %>
+    <% options.each do |option| %>
+      <%= render option %>
+    <% end %>
+  <% else %>
+    <li role="option" tabindex="-1" class="hw-combobox__option hw-combobox__option--no-results">
+      No results found.
+    </li>
   <% end %>
 <% end %>


### PR DESCRIPTION
This is my first stab at [#210 "Optional message to show for "no results found"".](https://github.com/josefarias/hotwire_combobox/discussions/210). In this state it's working, but far from perfect.

Here's a screenshot:

![CleanShot 2024-10-31 at 21 05 30@2x](https://github.com/user-attachments/assets/939c0026-60f6-40ea-9d16-33e9b8645dda)

Couple of points:

* How far do you want to make this customizable? And what would be the way for that? I was thinking option on the combobox tag that get's passed down. Or maybe it can be done through css `content` with variables? But that's also a bit ugly. Maybe people even want to be able to render a different partial/component/renderable? I'm not sure what direction to take it in.
* What about creating `HotwireCombobox::Listbox::EmptyOption` instead of rendering erb directly?
* I botched the css on purpose, as you probably have a way better idea how you want that structured. I can't get the `hw-combobox__option--no-results` to be more selective than `hw-combobox__option` 😑.
* A bit more custom, but in my use case I only return results when the `q` param has more than 2 characters (basically a `if params[:q] && params[:q].size > 2 ... else []` in my controller). This would show the no results found immediately when opening the combobox and when you've typed less the 2 chars. What would be a good way to control that from the server's side?

Hopefully this can serve as a starting point and we can implement something nice :)