### PR TITLE
Make pagination wrapper shorter

### DIFF
--- a/app/views/hotwire_combobox/_component.html.erb
+++ b/app/views/hotwire_combobox/_component.html.erb
@@ -20,7 +20,7 @@
       }
 
       .hw_combobox__pagination__wrapper {
-        height: 5px;
+        height: 1px;
       }
     <% end %>
 


### PR DESCRIPTION
This was given a height in https://github.com/josefarias/hotwire_combobox/pull/157

5px is too much and looks bad. Hopefully 1px is makes it unnoticeable.