### PR TITLE
Don't dispatch selection event on esc

### DIFF
--- a/app/assets/javascripts/hotwire_combobox.esm.js
+++ b/app/assets/javascripts/hotwire_combobox.esm.js
@@ -1521,9 +1521,8 @@ Combobox.Toggle = Base => class extends Base {
 
       this.expandedValue = false;
 
-      this._dispatchSelectionEvent();
-
       if (inputType != "hw:keyHandler:escape") {
+        this._dispatchSelectionEvent();
         this._createChip(shouldReopen);
       }
 

--- a/app/assets/javascripts/hw_combobox/models/combobox/toggle.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/toggle.js
@@ -24,9 +24,8 @@ Combobox.Toggle = Base => class extends Base {
 
       this.expandedValue = false
 
-      this._dispatchSelectionEvent()
-
       if (inputType != "hw:keyHandler:escape") {
+        this._dispatchSelectionEvent()
         this._createChip(shouldReopen)
       }
 


### PR DESCRIPTION
Feels like whatever is listening for a selection event shouldn't fire when closing via the escape key.