### PR TITLE
Add hidden field customization support

### DIFF
--- a/app/presenters/hotwire_combobox/component.rb
+++ b/app/presenters/hotwire_combobox/component.rb
@@ -18,6 +18,7 @@ class HotwireCombobox::Component
     dialog_label: nil,
     form: nil,
     free_text: false,
+    hidden_field: {},
     id: nil,
     input: {},
     label: nil,
@@ -30,9 +31,11 @@ class HotwireCombobox::Component
     request: nil,
     value: nil, **rest)
     @view, @autocomplete, @id, @name, @value, @form, @async_src, @label, @free_text, @request,
-    @preload, @name_when_new, @open, @data, @mobile_at, @multiselect_chip_src, @options, @dialog_label =
+    @preload, @name_when_new, @open, @data, @mobile_at, @multiselect_chip_src, @options, @dialog_label,
+    @hidden_field =
       view, autocomplete, id, name.to_s, value, form, async_src, label, free_text, request,
-      preload, name_when_new, open, data, mobile_at, multiselect_chip_src, options, dialog_label
+      preload, name_when_new, open, data, mobile_at, multiselect_chip_src, options, dialog_label,
+      hidden_field
 
     @combobox_attrs = input.reverse_merge(rest).deep_symbolize_keys
     @association_name = association_name || infer_association_name
@@ -47,7 +50,8 @@ class HotwireCombobox::Component
 
   private
     attr_reader :view, :autocomplete, :id, :name, :value, :form, :free_text, :open, :request,
-      :data, :combobox_attrs, :mobile_at, :association_name, :multiselect_chip_src, :preload
+      :data, :combobox_attrs, :mobile_at, :association_name, :multiselect_chip_src, :preload,
+      :hidden_field
 
     def canonical_id
       @canonical_id ||= id || form&.field_id(name) || SecureRandom.uuid

--- a/app/presenters/hotwire_combobox/component/markup/hidden_field.rb
+++ b/app/presenters/hotwire_combobox/component/markup/hidden_field.rb
@@ -2,7 +2,8 @@ module HotwireCombobox::Component::Markup::HiddenField
   def hidden_field_attrs
     customize :hidden_field, base: {
       id: hidden_field_id, name: hidden_field_name, value: hidden_field_value,
-      data: { hw_combobox_target: "hiddenField" } }
+      data: { hw_combobox_target: "hiddenField" }
+    }.merge(hidden_field)
   end
 
   private


### PR DESCRIPTION
I needed a way to specify extra attributes on the hidden field. For example, specifying the `form` attribute to target a specific form on the page.

This adds the ability to specific extra attributes on `hidden_field` the same way that `input` works.

```erb
  <%= combobox_tag :id, users_path, placeholder: "Search users", hidden_field: {form: :user} %>
```