### PR TITLE
Implement UUID v4 with crypto.getRandomValues()

### DIFF
--- a/app/assets/javascripts/hotwire_combobox.esm.js
+++ b/app/assets/javascripts/hotwire_combobox.esm.js
@@ -150,6 +150,15 @@ function nextEventLoopTick() {
   return new Promise((resolve) => setTimeout(() => resolve(), 0))
 }
 
+function randomUUID() {
+  const uuidPattern = "10000000-1000-4000-8000-100000000000";
+
+  return uuidPattern.replace(/[018]/g, (match) => {
+    const randomByte = crypto.getRandomValues(new Uint8Array(1))[0];
+    return (match ^ (randomByte & 15) >> (match / 4)).toString(16)
+  })
+}
+
 Combobox.Autocomplete = Base => class extends Base {
   _connectListAutocomplete() {
     if (!this._autocompletesList) {
@@ -213,7 +222,7 @@ Combobox.Callbacks = Base => class extends Base {
   }
 
   _enqueueCallback() {
-    const callbackId = crypto.randomUUID();
+    const callbackId = randomUUID();
     this.callbackQueue.push(callbackId);
     return callbackId
   }

--- a/app/assets/javascripts/hw_combobox/helpers.js
+++ b/app/assets/javascripts/hw_combobox/helpers.js
@@ -95,3 +95,12 @@ export function nextAnimationFrame() {
 export function nextEventLoopTick() {
   return new Promise((resolve) => setTimeout(() => resolve(), 0))
 }
+
+export function randomUUID() {
+  const uuidPattern = "10000000-1000-4000-8000-100000000000"
+
+  return uuidPattern.replace(/[018]/g, (match) => {
+    const randomByte = crypto.getRandomValues(new Uint8Array(1))[0]
+    return (match ^ (randomByte & 15) >> (match / 4)).toString(16)
+  })
+}

--- a/app/assets/javascripts/hw_combobox/models/combobox/callbacks.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/callbacks.js
@@ -1,4 +1,5 @@
 import Combobox from "hw_combobox/models/combobox/base"
+import { randomUUID } from "hw_combobox/helpers";
 
 const MAX_CALLBACK_ATTEMPTS = 3
 
@@ -9,7 +10,7 @@ Combobox.Callbacks = Base => class extends Base {
   }
 
   _enqueueCallback() {
-    const callbackId = crypto.randomUUID()
+    const callbackId = randomUUID()
     this.callbackQueue.push(callbackId)
     return callbackId
   }

--- a/app/assets/javascripts/hw_combobox/models/combobox/callbacks.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/callbacks.js
@@ -1,5 +1,5 @@
 import Combobox from "hw_combobox/models/combobox/base"
-import { randomUUID } from "hw_combobox/helpers";
+import { randomUUID } from "hw_combobox/helpers"
 
 const MAX_CALLBACK_ATTEMPTS = 3
 


### PR DESCRIPTION
This PR implements a custom `randomUUID` function to replace the `crypto.randomUUID` that could not be used in insecure environments due to the nature of `crypto`.

Detailed discussion here https://github.com/josefarias/hotwire_combobox/discussions/223