### PR TITLE
Support array query params

### DIFF
--- a/lib/hotwire_combobox/helper.rb
+++ b/lib/hotwire_combobox/helper.rb
@@ -115,7 +115,7 @@ module HotwireCombobox
 
       def hw_uri_with_params(url_or_path, **params)
         URI.parse(url_or_path).tap do |url_or_path|
-          query = URI.decode_www_form(url_or_path.query || "").to_h.merge(params.compact_blank.stringify_keys)
+          query = Rack::Utils.parse_query(url_or_path.query || "").merge(params.compact_blank.stringify_keys)
           url_or_path.query = URI.encode_www_form query
         end.to_s
       rescue URI::InvalidURIError

--- a/lib/hotwire_combobox/helper.rb
+++ b/lib/hotwire_combobox/helper.rb
@@ -115,8 +115,8 @@ module HotwireCombobox
 
       def hw_uri_with_params(url_or_path, **params)
         URI.parse(url_or_path).tap do |url_or_path|
-          query = Rack::Utils.parse_query(url_or_path.query || "").merge(params.compact_blank.stringify_keys)
-          url_or_path.query = URI.encode_www_form query
+          query = Rack::Utils.parse_nested_query(url_or_path.query || "").merge(params.compact_blank.stringify_keys)
+          url_or_path.query = Rack::Utils.build_nested_query query
         end.to_s
       rescue URI::InvalidURIError
         url_or_path

--- a/test/helpers/hotwire_combobox/helper_test.rb
+++ b/test/helpers/hotwire_combobox/helper_test.rb
@@ -138,6 +138,15 @@ class HotwireCombobox::HelperTest < ApplicationViewTestCase
     assert_attrs html, tag_name: "turbo-frame", src: "/foo?bar=baz&qux=quux&page=2&format=turbo_stream"
   end
 
+  test "hw_paginated_combobox_options includes array params" do
+    request.expects(:path).returns("/foo")
+    request.expects(:query_parameters).returns({ ary: [ 1, 2 ] }.with_indifferent_access)
+
+    html = hw_paginated_combobox_options [], next_page: 2
+
+    assert_attrs html, tag_name: "turbo-frame", src: "/foo?ary=1&ary=2&page=2&format=turbo_stream"
+  end
+
   test "single repeating character values" do
     form = form_with model: OpenStruct.new(run_at: "* * * * *", persisted?: true, model_name: OpenStruct.new(param_key: :foo)), url: "#" do |form|
       form.combobox :run_at, [ "@hourly", "@daily", "@weekly", "@monthly", "@every 4h", "0 12 * * *" ], free_text: true

--- a/test/helpers/hotwire_combobox/helper_test.rb
+++ b/test/helpers/hotwire_combobox/helper_test.rb
@@ -144,7 +144,7 @@ class HotwireCombobox::HelperTest < ApplicationViewTestCase
 
     html = hw_paginated_combobox_options [], next_page: 2
 
-    assert_attrs html, tag_name: "turbo-frame", src: "/foo?ary=1&ary=2&page=2&format=turbo_stream"
+    assert_attrs CGI.unescape(html), tag_name: "turbo-frame", src: "/foo?ary[]=1&ary[]=2&page=2&format=turbo_stream"
   end
 
   test "single repeating character values" do


### PR DESCRIPTION
`URI.decode_www_form` doesn’t support arrays but `Rack::Utils.parse_query` does. I'm passing a list of IDs to exclude which currently is reduced to only the final value:

```erb
<%= form.combobox :membership_id, members_path(exclude: [1,2]) %>
<%# src => /members?exclude[]=3&…  not /members?exclude[]=1&exclude=2&… %>
```

This also addresses issue #211 