### PR TITLE
Remove sync preselection size limit

### DIFF
--- a/app/assets/javascripts/hotwire_combobox.esm.js
+++ b/app/assets/javascripts/hotwire_combobox.esm.js
@@ -1175,7 +1175,7 @@ Combobox.Selection = Base => class extends Base {
   }
 
   _preselectSingle() {
-    if (this._isSingleSelect && this._hasValueButNoSelection && this._allOptions.length < 100) {
+    if (this._isSingleSelect && this._hasValueButNoSelection) {
       const option = this._optionElementWithValue(this._fieldValue);
       if (option) this._markSelected(option);
     }

--- a/app/assets/javascripts/hw_combobox/models/combobox/selection.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/selection.js
@@ -85,7 +85,7 @@ Combobox.Selection = Base => class extends Base {
   }
 
   _preselectSingle() {
-    if (this._isSingleSelect && this._hasValueButNoSelection && this._allOptions.length < 100) {
+    if (this._isSingleSelect && this._hasValueButNoSelection) {
       const option = this._optionElementWithValue(this._fieldValue)
       if (option) this._markSelected(option)
     }


### PR DESCRIPTION
Original motivation was to encourage users to use async pagination when their collections were too large.

I’ve come to realize some collections are hard to cache and async pagination isn’t always straightforward. Although I _would_ recommend implementers solve that for their own app’s sake, there’s no reason to make life harder for them through what was meant to be a gentle nudge.