### PR TITLE
 Pass in loading: :lazy to _pagination partial from _next_page partial 

### DIFF
--- a/app/views/hotwire_combobox/_next_page.turbo_stream.erb
+++ b/app/views/hotwire_combobox/_next_page.turbo_stream.erb
@@ -2,5 +2,5 @@
 
 <%= turbo_stream.remove hw_pagination_frame_wrapper_id(for_id) %>
 <%= turbo_stream.append hw_listbox_id(for_id) do %>
-  <%= render "hotwire_combobox/pagination", for_id: for_id, src: src %>
+  <%= render "hotwire_combobox/pagination", for_id: for_id, src: src, loading: :lazy %>
 <% end %>

--- a/app/views/hotwire_combobox/_pagination.html.erb
+++ b/app/views/hotwire_combobox/_pagination.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (for_id:, src:, loading: :lazy) -%>
+<%# locals: (for_id:, src:, loading:) -%>
 
 <%= tag.li id: hw_pagination_frame_wrapper_id(for_id), class: "hw_combobox__pagination__wrapper",
       data: { hw_combobox_target: "endOfOptionsStream", input_type: params[:input_type], callback_id: params[:callback_id] },


### PR DESCRIPTION
I'm running Rails 7.0 and when I booted up this package for a super simple async case, I would receive the error `ActionView::Template::Error (undefined local variable or method 'loading' for #<ActionView::Base:0x000000000620e8>` from within `app/views/hotwire_combobox/_pagination.html.erb`:

```ruby
# app/views/hotwire_combobox/_pagination.html.erb
<%# locals: (for_id:, src:, loading: :lazy) -%>

<%= tag.li id: hw_pagination_frame_wrapper_id(for_id), class: "hw_combobox__pagination__wrapper",
      data: { hw_combobox_target: "endOfOptionsStream", input_type: params[:input_type], callback_id: params[:callback_id] },
      aria: { hidden: true } do %>
  <%= turbo_frame_tag hw_pagination_frame_id(for_id), src: src, loading: loading %>
<% end %>
```

After a bit of digging, I figured out that it was coming from `app/views/hotwire_combobox/_next_page.turbo_stream.erb`, which currently looks like this:

```ruby
# app/views/hotwire_combobox/_next_page.turbo_stream.erb
<%= turbo_stream.append hw_listbox_id(for_id) do %>
  <%= render "hotwire_combobox/pagination", for_id: for_id, src: src %>
<% end %>
```

While I'm definitely confused why no one else seems to be hitting this issue, the fix is super simple - just pass in `loading: :lazy` to `_pagination`. I assume we'd always want lazy loading on the next_page partial so that it always only loads once the user scrolls down. 

This fixed the issue for me and now I'm up and running.