### PR TITLE
Add `disabled` guard clause to clearOrToggleOnHandleClick

### DIFF
--- a/app/assets/javascripts/hotwire_combobox.esm.js
+++ b/app/assets/javascripts/hotwire_combobox.esm.js
@@ -1574,6 +1574,8 @@ Combobox.Toggle = Base => class extends Base {
   }
 
   clearOrToggleOnHandleClick() {
+    if (this.comboboxTarget.disabled) return
+
     if (this._isQueried) {
       this._clearQuery();
       this.open();

--- a/app/assets/javascripts/hw_combobox/models/combobox/toggle.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/toggle.js
@@ -57,6 +57,8 @@ Combobox.Toggle = Base => class extends Base {
   }
 
   clearOrToggleOnHandleClick() {
+    if (this.comboboxTarget.disabled) return
+
     if (this._isQueried) {
       this._clearQuery()
       this.open()

--- a/test/dummy/app/controllers/comboboxes_controller.rb
+++ b/test/dummy/app/controllers/comboboxes_controller.rb
@@ -121,6 +121,9 @@ class ComboboxesController < ApplicationController
   def turbo_streamed_block
   end
 
+  def disabled
+  end
+
   private
     delegate :combobox_options, :html_combobox_options, to: "ApplicationController.helpers", private: true
 

--- a/test/dummy/app/views/comboboxes/disabled.html.erb
+++ b/test/dummy/app/views/comboboxes/disabled.html.erb
@@ -1,0 +1,1 @@
+<%= combobox_tag "state", @state_options, id: "state-field", disabled: true %>

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   get "custom_attrs", to: "comboboxes#custom_attrs"
   get "custom_events", to: "comboboxes#custom_events"
   get "dialog", to: "comboboxes#dialog"
+  get "disabled", to: "comboboxes#disabled"
   get "enum", to: "comboboxes#enum"
   get "external_clear", to: "comboboxes#external_clear"
   get "form_object", to: "comboboxes#form_object"

--- a/test/system/hotwire_combobox_test.rb
+++ b/test/system/hotwire_combobox_test.rb
@@ -179,4 +179,14 @@ class HotwireComboboxTest < ApplicationSystemTestCase
     visit turbo_streamed_block_path(format: :turbo_stream)
     assert_text "Alabama"
   end
+
+  test "combobox does not open when disabled" do
+    visit disabled_path
+
+    open_combobox "#state-field"
+    assert_closed_combobox
+
+    find('[data-hw-combobox-target="handle"]').click
+    assert_closed_combobox
+  end
 end


### PR DESCRIPTION
If a `disabled` attribute was present on the combobox, the interaction with the input was correctly disabled. However, the handle was still clickable and would open the dropdown. This adds a guard clause to the click handler to return early if its controller's `comboboxTarget` is disabled.