### PR TITLE
Add debounce_interval config option

### DIFF
--- a/app/assets/javascripts/controllers/hw_combobox_controller.js
+++ b/app/assets/javascripts/controllers/hw_combobox_controller.js
@@ -44,6 +44,7 @@ export default class HwComboboxController extends Concerns(...concerns) {
     asyncSrc: String,
     autocompletableAttribute: String,
     autocomplete: String,
+    debounceInterval: Number,
     expanded: Boolean,
     filterableAttribute: String,
     nameWhenNew: String,

--- a/app/assets/javascripts/hotwire_combobox.esm.js
+++ b/app/assets/javascripts/hotwire_combobox.esm.js
@@ -91,7 +91,7 @@ function startsWith(string, substring) {
   return string.toLowerCase().startsWith(substring.toLowerCase())
 }
 
-function debounce(fn, delay = 150) {
+function debounce(fn, delay) {
   let timeoutId = null;
 
   return (...args) => {
@@ -668,7 +668,7 @@ Combobox.Filtering = Base => class extends Base {
   }
 
   _initializeFiltering() {
-    this._debouncedFilterAsync = debounce(this._debouncedFilterAsync.bind(this));
+    this._debouncedFilterAsync = debounce(this._debouncedFilterAsync.bind(this), this.debounceIntervalValue);
   }
 
   _filter(inputType) {
@@ -1752,6 +1752,7 @@ class HwComboboxController extends Concerns(...concerns) {
     asyncSrc: String,
     autocompletableAttribute: String,
     autocomplete: String,
+    debounceInterval: Number,
     expanded: Boolean,
     filterableAttribute: String,
     nameWhenNew: String,

--- a/app/assets/javascripts/hw_combobox/helpers.js
+++ b/app/assets/javascripts/hw_combobox/helpers.js
@@ -37,7 +37,7 @@ export function startsWith(string, substring) {
   return string.toLowerCase().startsWith(substring.toLowerCase())
 }
 
-export function debounce(fn, delay = 150) {
+export function debounce(fn, delay) {
   let timeoutId = null
 
   return (...args) => {

--- a/app/assets/javascripts/hw_combobox/models/combobox/filtering.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/filtering.js
@@ -30,7 +30,7 @@ Combobox.Filtering = Base => class extends Base {
   }
 
   _initializeFiltering() {
-    this._debouncedFilterAsync = debounce(this._debouncedFilterAsync.bind(this))
+    this._debouncedFilterAsync = debounce(this._debouncedFilterAsync.bind(this), this.debounceIntervalValue)
   }
 
   _filter(inputType) {

--- a/app/presenters/hotwire_combobox/component.rb
+++ b/app/presenters/hotwire_combobox/component.rb
@@ -15,6 +15,7 @@ class HotwireCombobox::Component
     async_src: nil,
     autocomplete: :both,
     data: {},
+    debounce_interval: 150,
     dialog_label: nil,
     form: nil,
     free_text: false,
@@ -30,9 +31,9 @@ class HotwireCombobox::Component
     request: nil,
     value: nil, **rest)
     @view, @autocomplete, @id, @name, @value, @form, @async_src, @label, @free_text, @request,
-    @preload, @name_when_new, @open, @data, @mobile_at, @multiselect_chip_src, @options, @dialog_label =
+    @preload, @name_when_new, @open, @data, @debounce_interval, @mobile_at, @multiselect_chip_src, @options, @dialog_label =
       view, autocomplete, id, name.to_s, value, form, async_src, label, free_text, request,
-      preload, name_when_new, open, data, mobile_at, multiselect_chip_src, options, dialog_label
+      preload, name_when_new, open, data, debounce_interval, mobile_at, multiselect_chip_src, options, dialog_label
 
     @combobox_attrs = input.reverse_merge(rest).deep_symbolize_keys
     @association_name = association_name || infer_association_name
@@ -47,7 +48,7 @@ class HotwireCombobox::Component
 
   private
     attr_reader :view, :autocomplete, :id, :name, :value, :form, :free_text, :open, :request,
-      :data, :combobox_attrs, :mobile_at, :association_name, :multiselect_chip_src, :preload
+      :data, :debounce_interval, :combobox_attrs, :mobile_at, :association_name, :multiselect_chip_src, :preload
 
     def canonical_id
       @canonical_id ||= id || form&.field_id(name) || SecureRandom.uuid

--- a/app/presenters/hotwire_combobox/component/markup/fieldset.rb
+++ b/app/presenters/hotwire_combobox/component/markup/fieldset.rb
@@ -26,6 +26,7 @@ module HotwireCombobox::Component::Markup::Fieldset
         hw_combobox_async_src_value: async_src,
         hw_combobox_prefilled_display_value: prefilled_display,
         hw_combobox_selection_chip_src_value: multiselect_chip_src,
+        hw_combobox_debounce_interval_value: debounce_interval,
         hw_combobox_filterable_attribute_value: "data-filterable-as",
         hw_combobox_autocompletable_attribute_value: "data-autocompletable-as",
         hw_combobox_selected_class: "hw-combobox__option--selected",

--- a/test/dummy/app/controllers/comboboxes_controller.rb
+++ b/test/dummy/app/controllers/comboboxes_controller.rb
@@ -124,6 +124,9 @@ class ComboboxesController < ApplicationController
   def disabled
   end
 
+  def debounced
+  end
+
   private
     delegate :combobox_options, :html_combobox_options, to: "ApplicationController.helpers", private: true
 

--- a/test/dummy/app/views/comboboxes/debounced.html.erb
+++ b/test/dummy/app/views/comboboxes/debounced.html.erb
@@ -1,0 +1,1 @@
+<%= combobox_tag "movie", movies_path, id: "movie-field", label: "Choose your movie!", debounce_interval: 500 %>

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   get "custom_events", to: "comboboxes#custom_events"
   get "dialog", to: "comboboxes#dialog"
   get "disabled", to: "comboboxes#disabled"
+  get "debounced", to: "comboboxes#debounced"
   get "enum", to: "comboboxes#enum"
   get "external_clear", to: "comboboxes#external_clear"
   get "form_object", to: "comboboxes#form_object"

--- a/test/system/debounce_test.rb
+++ b/test/system/debounce_test.rb
@@ -1,0 +1,24 @@
+require "system_test_helper"
+
+class DebounceTest < ApplicationSystemTestCase
+  test "setting the debounce attribute actually debounces" do
+    visit debounced_path
+
+    open_combobox "#movie-field"
+
+    assert_text "12 Angry Men"
+    type_in_combobox "#movie-field", "wh"
+
+    sleep 0.100
+    assert_text "12 Angry Men"
+
+    sleep 0.500
+    assert_no_text "12 Angry Men"
+    assert_text "Whiplash"
+    assert_options_with count: 2
+    clear_autocompleted_portion "#movie-field"
+    delete_from_combobox "#movie-field", "wh", original: "wh"
+    assert_combobox_display_and_value "#movie-field", "", nil
+    assert_text "12 Angry Men"
+  end
+end


### PR DESCRIPTION
When using a web request to filter the options in the combobox, adding the `debounce_interval` option will allow you to configure the time between requests made to the server.

closes #227