### PR TITLE
Add ability to disable specific elements in a ComboBox

### DIFF
--- a/app/assets/javascripts/hw_combobox/helpers.js
+++ b/app/assets/javascripts/hw_combobox/helpers.js
@@ -6,6 +6,10 @@ export function visible(target) {
   return !(target.hidden || target.closest("[hidden]"))
 }
 
+export function enabled(target) {
+  return !(target.ariaDisabled === "true" || target.closest("[aria-disabled='true']"))
+}
+
 export function wrapAroundAccess(array, index) {
   const first = 0
   const last = array.length - 1

--- a/app/assets/javascripts/hw_combobox/models/combobox/navigation.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/navigation.js
@@ -27,7 +27,7 @@ Combobox.Navigation = Base => class extends Base {
       cancel(event)
     },
     End: (event) => {
-      this._selectIndex(this._visibleOptionElements.length - 1)
+      this._selectIndex(this._selectableOptionElements.length - 1)
       cancel(event)
     },
     Enter: (event) => {

--- a/app/assets/javascripts/hw_combobox/models/combobox/options.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/options.js
@@ -1,5 +1,5 @@
 import Combobox from "hw_combobox/models/combobox/base"
-import { visible } from "hw_combobox/helpers"
+import { visible, enabled } from "hw_combobox/helpers"
 
 Combobox.Options = Base => class extends Base {
   _resetOptionsSilently() {
@@ -39,6 +39,10 @@ Combobox.Options = Base => class extends Base {
     return [ ...this._allFilterableOptionElements ].filter(visible)
   }
 
+  get _selectableOptionElements() {
+    return [ ...this._visibleOptionElements ].filter(enabled)
+  }
+
   get _selectedOptionElement() {
     return this._actingListbox.querySelector("[role=option][aria-selected=true]:not([data-multiselected])")
   }
@@ -48,7 +52,7 @@ Combobox.Options = Base => class extends Base {
   }
 
   get _selectedOptionIndex() {
-    return [ ...this._visibleOptionElements ].indexOf(this._selectedOptionElement)
+    return [ ...this._selectableOptionElements ].indexOf(this._selectedOptionElement)
   }
 
   get _isUnjustifiablyBlank() {

--- a/app/assets/javascripts/hw_combobox/models/combobox/selection.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/selection.js
@@ -21,8 +21,8 @@ Combobox.Selection = Base => class extends Base {
       this._deselect()
     } else if (inputType === "hw:lockInSelection" && this._ensurableOption) {
       this._select(this._ensurableOption, this._softAutocomplete.bind(this))
-    } else if (this._isOpen && this._visibleOptionElements[0]) {
-      this._select(this._visibleOptionElements[0], this._softAutocomplete.bind(this))
+    } else if (this._isOpen && this._selectableOptionElements[0]) {
+      this._select(this._selectableOptionElements[0], this._softAutocomplete.bind(this))
     } else if (this._isOpen) {
       this._resetOptionsAndNotify()
       this._markInvalid()
@@ -80,7 +80,7 @@ Combobox.Selection = Base => class extends Base {
   }
 
   _selectIndex(index) {
-    const option = wrapAroundAccess(this._visibleOptionElements, index)
+    const option = wrapAroundAccess(this._selectableOptionElements, index)
     this._forceSelectionWithoutFiltering(option)
   }
 
@@ -150,6 +150,6 @@ Combobox.Selection = Base => class extends Base {
   }
 
   get _ensurableOption() {
-    return this._selectedOptionElement || this._visibleOptionElements[0]
+    return this._selectedOptionElement || this._selectableOptionElements[0]
   }
 }

--- a/app/assets/stylesheets/hotwire_combobox.css
+++ b/app/assets/stylesheets/hotwire_combobox.css
@@ -173,6 +173,11 @@
   border-bottom: var(--hw-border-width--slim) solid var(--hw-border-color);
 }
 
+.hw-combobox__option--disabled {
+  pointer-events:none; 
+  opacity:0.6; 
+}
+
 .hw-combobox__option:hover,
 .hw-combobox__option--navigated,
 .hw-combobox__option--selected {

--- a/app/presenters/hotwire_combobox/listbox/option.rb
+++ b/app/presenters/hotwire_combobox/listbox/option.rb
@@ -18,15 +18,16 @@ class HotwireCombobox::Listbox::Option
   end
 
   private
-    Data = Struct.new :id, :value, :display, :content, :blank, :filterable_as, :autocompletable_as, keyword_init: true
+    Data = Struct.new :id, :value, :display, :content, :blank, :filterable_as, :disabled, :autocompletable_as, keyword_init: true
 
     attr_reader :option
 
     def options
       { id: id, role: :option, tabindex: "-1",
-        class: [ "hw-combobox__option", { "hw-combobox__option--blank": blank? } ],
+        disabled: disabled?,
+        class: [ "hw-combobox__option", { "hw-combobox__option--blank": blank?, "hw-combobox__option--disabled": disabled? } ],
         data: { action: "click->hw-combobox#selectOnClick", filterable_as: filterable_as, autocompletable_as: autocompletable_as, value: value },
-        aria: { selected: false } }
+        aria: { selected: false,  disabled: ("true" if disabled?) } }
     end
 
     def id
@@ -43,5 +44,9 @@ class HotwireCombobox::Listbox::Option
 
     def blank?
       option.try(:blank).present?
+    end
+
+    def disabled?
+      option.try(:disabled).present?
     end
 end

--- a/test/dummy/app/controllers/comboboxes_controller.rb
+++ b/test/dummy/app/controllers/comboboxes_controller.rb
@@ -122,6 +122,9 @@ class ComboboxesController < ApplicationController
   end
 
   def disabled
+    @disabled_options = State.all.map do |state|
+      { display: state.name, value: state.abbreviation, disabled: state.abbreviation[0] == "A" ? "true" : nil }
+    end
   end
 
   private

--- a/test/dummy/app/views/comboboxes/disabled.html.erb
+++ b/test/dummy/app/views/comboboxes/disabled.html.erb
@@ -1,1 +1,6 @@
+<%= label_tag "state-field", "State (disabled)" %>
 <%= combobox_tag "state", @state_options, id: "state-field", disabled: true %>
+<br>
+
+<%= label_tag "disabled-state-field", "State (with disabled options)" %>
+<%= combobox_tag "state_disabled_options", @disabled_options, id: "disabled-state-field"%>

--- a/test/presenters/hotwire_combobox/listbox/option_test.rb
+++ b/test/presenters/hotwire_combobox/listbox/option_test.rb
@@ -37,6 +37,16 @@ class HotwireCombobox::Listbox::OptionTest < ApplicationViewTestCase
     assert_attrs render(option), tag_name: :li, "data-autocompletable-as": "bar"
   end
 
+  test "renders option with aria-disabled when disabled" do
+    option = { disabled: true }
+    assert_attrs render(option), tag_name: :li, "aria-disabled": "true"
+  end
+
+  test "renders option without aria-disabled when not disabled" do
+    option = { disabled: false }
+    assert_attrs render(option), tag_name: :li
+  end
+
   private
     def render(option)
       view.render HotwireCombobox::Listbox::Option.new(option)

--- a/test/system/hotwire_combobox_test.rb
+++ b/test/system/hotwire_combobox_test.rb
@@ -186,7 +186,24 @@ class HotwireComboboxTest < ApplicationSystemTestCase
     open_combobox "#state-field"
     assert_closed_combobox
 
-    find('[data-hw-combobox-target="handle"]').click
+    find('#state-field').click
     assert_closed_combobox
+  end
+
+  test "combobox does not allow disabled options to be selected" do
+    visit disabled_path
+
+    open_combobox "#disabled-state-field"
+    alaska_option = find('li', text: 'Alaska', match: :first)
+
+    assert_equal 'true', alaska_option[:'aria-disabled']
+    assert_includes alaska_option[:class], 'hw-combobox__option--disabled'
+  end
+
+  test "combobox with disabled options allows selection of enabled options" do
+    visit disabled_path
+    open_combobox "#disabled-state-field"
+    click_on_option "California"
+    assert_combobox_display_and_value "#disabled-state-field", "California", "CA"
   end
 end


### PR DESCRIPTION
### What changed:

- feat: Allow users to add the attribute disabled to Listbox::Options.
-  feat: Added CSS for disabled options in the listbox.
- feat: add options collection for list boxes that displays disabled options but excludes them from selection.
-  test: Added a disabled options combobox_tag to the disabled.html.erb view.


### Additional Information

- We decided it was best to only support disabled options when passing a hash to `combobox_tag`.
- This can be further expanded if we would like to look into creating a helper function for combobox_options, like `options_for_select`.
- This PR resolves [discussion 126](https://github.com/josefarias/hotwire_combobox/discussions/126).


### Testing Instructions

1. Run the dummy app and navigate to: `/disabled`.
2. Click on the ComboBox labeled, `State (with disabled options)`.
3. Expect all states that start with the letter 'A' to be disabled.
4. Ensure you cannot select them and that you cannot navigate to them.
5. Ensure you cannot get to any disabled elements by using the `Home` or `End` key press.
6. Ensure you cannot get to any disabled elements by using the search feature.