### PR TITLE
Add hw-combobox:clear event

### DIFF
--- a/app/assets/javascripts/hotwire_combobox.esm.js
+++ b/app/assets/javascripts/hotwire_combobox.esm.js
@@ -350,6 +350,17 @@ Combobox.Events = Base => class extends Base {
     });
   }
 
+  _dispatchClearEvent() {
+    dispatch("hw-combobox:clear", {
+      target: this.element,
+      detail: {
+        previousValue: this._fieldValue,
+        previousDisplay: this._fullQuery,
+        fieldName: this._fieldName
+      }
+    });
+  }
+
   get _eventableDetails() {
     return {
       value: this._incomingFieldValueString,
@@ -1576,7 +1587,8 @@ Combobox.Toggle = Base => class extends Base {
   clearOrToggleOnHandleClick() {
     if (this.comboboxTarget.disabled) return
 
-    if (this._isQueried) {
+    if (this._isQueried || this._hasFieldValue) {
+      this._dispatchClearEvent();
       this._clearQuery();
       this.open();
     } else {

--- a/app/assets/javascripts/hw_combobox/models/combobox/events.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/events.js
@@ -25,6 +25,17 @@ Combobox.Events = Base => class extends Base {
     })
   }
 
+  _dispatchClearEvent() {
+    dispatch("hw-combobox:clear", {
+      target: this.element,
+      detail: {
+        previousValue: this._fieldValue,
+        previousDisplay: this._fullQuery,
+        fieldName: this._fieldName
+      }
+    })
+  }
+
   get _eventableDetails() {
     return {
       value: this._incomingFieldValueString,

--- a/app/assets/javascripts/hw_combobox/models/combobox/toggle.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/toggle.js
@@ -59,7 +59,8 @@ Combobox.Toggle = Base => class extends Base {
   clearOrToggleOnHandleClick() {
     if (this.comboboxTarget.disabled) return
 
-    if (this._isQueried) {
+    if (this._isQueried || this._hasFieldValue) {
+      this._dispatchClearEvent()
       this._clearQuery()
       this.open()
     } else {

--- a/test/dummy/app/controllers/comboboxes_controller.rb
+++ b/test/dummy/app/controllers/comboboxes_controller.rb
@@ -67,6 +67,9 @@ class ComboboxesController < ApplicationController
   def include_blank
   end
 
+  def clear_events
+  end
+
   def custom_events
   end
 

--- a/test/dummy/app/javascript/controllers/combobox/clear_events_controller.js
+++ b/test/dummy/app/javascript/controllers/combobox/clear_events_controller.js
@@ -1,0 +1,34 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["clearLog"]
+
+  connect() {
+    this.clearCount = 0
+  }
+
+  onClear(event) {
+    this.clearCount++
+
+    const timestamp = new Date().toLocaleTimeString()
+    const logEntry = [
+      `[${timestamp}]`,
+      `  Clear Event #${this.clearCount}:`,
+      `  Previous Value: "${event.detail.previousValue || '<empty>'}"`,
+      `  Previous Display: "${event.detail.previousDisplay || '<empty>'}"`,
+      `  Field Name: "${event.detail.fieldName}"`,
+      ""
+    ].join("\n")
+
+    if (this.clearCount === 1) {
+      this.clearLogTarget.textContent = logEntry
+    } else {
+      this.clearLogTarget.textContent = logEntry + this.clearLogTarget.textContent
+    }
+  }
+
+  clearLogs() {
+    this.clearLogTarget.textContent = "No clear events yet. Type something and then click the × button."
+    this.clearCount = 0
+  }
+}

--- a/test/dummy/app/views/comboboxes/clear_events.html.erb
+++ b/test/dummy/app/views/comboboxes/clear_events.html.erb
@@ -1,0 +1,29 @@
+<%= tag.style nonce: content_security_policy_nonce do %>
+  .event-log {
+    background: #f8f9fa;
+    padding: 1rem;
+    border: 1px solid #dee2e6;
+    font-family: monospace;
+    white-space: pre-wrap;
+    margin: 1rem 0;
+  }
+<% end %>
+
+<div data-controller="combobox--clear-events">
+  <p>Type in the combobox and then click the "×" button to see the clear event details.</p>
+
+  <%= combobox_tag :state, @state_options,
+      id: "state-field",
+      placeholder: "Type to search states...",
+      data: {
+        action: "hw-combobox:clear->combobox--clear-events#onClear"
+      } %>
+
+  <div class="event-log" data-combobox--clear-events-target="clearLog">
+    No clear events yet. Type something and then click the × button.
+  </div>
+
+  <button type="button" data-action="click->combobox--clear-events#clearLogs">
+    Clear Log
+  </button>
+</div>

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   get "async", to: "comboboxes#async"
   get "async_html", to: "comboboxes#async_html"
   get "async_preload", to: "comboboxes#async_preload"
+  get "clear_events", to: "comboboxes#clear_events"
   get "conflicting_order", to: "comboboxes#conflicting_order"
   get "custom_attrs", to: "comboboxes#custom_attrs"
   get "custom_events", to: "comboboxes#custom_events"

--- a/test/system/clear_events_test.rb
+++ b/test/system/clear_events_test.rb
@@ -1,0 +1,29 @@
+require "system_test_helper"
+
+class ClearEventsTest < ApplicationSystemTestCase
+  test "clear events with partial text input" do
+    visit clear_events_path
+
+    type_in_combobox "#state-field", "Ala"
+    find(".hw-combobox__handle").click
+
+    assert_text "Clear Event #1"
+    assert_text "Previous Display: \"Alabama\""
+    assert_text "Field Name: \"state\""
+    assert_text "Previous Value: \"AL\""
+  end
+
+  test "clear events with confirmed selection" do
+    visit clear_events_path
+
+    type_in_combobox "#state-field", "Alabama"
+    click_away
+
+    find(".hw-combobox__handle").click
+
+    assert_text "Clear Event #1"
+    assert_text "Previous Display: \"Alabama\""
+    assert_text "Field Name: \"state\""
+    assert_text "Previous Value: \"AL\""
+  end
+end


### PR DESCRIPTION
##  Why

As discussed in #264, the HotwireCombobox dispatches custom events for most user interactions (preselection, selection, etc.) but was missing an event when users clear the combobox using the × button. This makes it difficult to perform cleanup actions when the combobox is cleared. 

##  Changes

- New event dispatch: Added `_dispatchClearEvent()` method that emits `hw-combobox:clear` with context data:
  - previousValue: The field value before clearing
  - previousDisplay: The displayed text before clearing
  - fieldName: The name of the field being cleared
- Added demo page demonstrating the event functionality

##  Usage

```erb
  <%= combobox_tag :state, states_path,
      data: {
        action: "hw-combobox:clear->my-controller#onClear"
      } %>
```

```js
  onClear(event) {
  console.log(`Cleared: ${event.detail.previousDisplay}`)
  console.log(`Previous value: ${event.detail.previousValue}`)
  // Perform cleanup actions...
}
```

  Closes #264