### PR TITLE
Fire preselection event when deleting

### DIFF
--- a/app/assets/javascripts/hotwire_combobox.esm.js
+++ b/app/assets/javascripts/hotwire_combobox.esm.js
@@ -1115,7 +1115,7 @@ Combobox.Selection = Base => class extends Base {
     if (this._shouldTreatAsNewOptionForFiltering(!isDeleteEvent({ inputType: inputType }))) {
       this._selectNew();
     } else if (isDeleteEvent({ inputType: inputType })) {
-      this._deselect();
+      this._deselectAndNotify();
     } else if (inputType === "hw:lockInSelection" && this._ensurableOption) {
       this._select(this._ensurableOption, this._softAutocomplete.bind(this));
     } else if (this._isOpen && this._visibleOptionElements[0]) {

--- a/app/assets/javascripts/hw_combobox/models/combobox/selection.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/selection.js
@@ -18,7 +18,7 @@ Combobox.Selection = Base => class extends Base {
     if (this._shouldTreatAsNewOptionForFiltering(!isDeleteEvent({ inputType: inputType }))) {
       this._selectNew()
     } else if (isDeleteEvent({ inputType: inputType })) {
-      this._deselect()
+      this._deselectAndNotify()
     } else if (inputType === "hw:lockInSelection" && this._ensurableOption) {
       this._select(this._ensurableOption, this._softAutocomplete.bind(this))
     } else if (this._isOpen && this._visibleOptionElements[0]) {

--- a/test/system/custom_events_test.rb
+++ b/test/system/custom_events_test.rb
@@ -108,4 +108,35 @@ class CustomEventsTest < ApplicationSystemTestCase
     assert_text "preselections: 6."
     assert_text "selections: 4."
   end
+
+  test "preselection event fires when clearing via the handle button" do
+    visit custom_events_path
+
+    open_combobox "#required"
+    type_in_combobox "#required", "A Beautiful Mind"
+    click_on_option "A Beautiful Mind"
+
+    assert_text "preselections: 1."
+
+    within "#preselection" do
+      assert_text "value: #{movies(:a_beautiful_mind).id}"
+    end
+
+    within selector_root("#required") do
+      find(".hw-combobox__handle").click
+    end
+
+    assert_text "preselections: 2."
+
+    within "#preselection" do
+      assert_text "event: hw-combobox:preselection"
+      assert_text "value: <empty>"
+      assert_text "previousValue: #{movies(:a_beautiful_mind).id}"
+    end
+  end
+
+  private
+    def selector_root(selector)
+      "fieldset[data-controller~='hw-combobox']:has(#{selector})"
+    end
 end


### PR DESCRIPTION
When the combobox input receives a deletion event (e.g. pressing backspace), we clear the current hidden input value. We fire preselection events every time the value changes, so I think deleting should behave the same way (i.e. treat `value1 -> value2` the same as `valueX -> no-value`).