### PR TITLE
Fix deprecation warning #render_in from latest Rails 8.2 change

### DIFF
--- a/app/presenters/hotwire_combobox/component.rb
+++ b/app/presenters/hotwire_combobox/component.rb
@@ -41,7 +41,7 @@ class HotwireCombobox::Component
     validate!
   end
 
-  def render_in(view_context, locals: nil, &block)
+  def render_in(view_context, **, &block)
     block.call(self) if block_given?
     view_context.render partial: "hotwire_combobox/component", locals: { component: self }, formats: [ :html ]
   end

--- a/app/presenters/hotwire_combobox/component.rb
+++ b/app/presenters/hotwire_combobox/component.rb
@@ -41,7 +41,7 @@ class HotwireCombobox::Component
     validate!
   end
 
-  def render_in(view_context, &block)
+  def render_in(view_context, locals: nil, &block)
     block.call(self) if block_given?
     view_context.render partial: "hotwire_combobox/component", locals: { component: self }, formats: [ :html ]
   end

--- a/app/presenters/hotwire_combobox/listbox/group.rb
+++ b/app/presenters/hotwire_combobox/listbox/group.rb
@@ -8,7 +8,7 @@ class HotwireCombobox::Listbox::Group
     @options = options
   end
 
-  def render_in(view, locals: nil)
+  def render_in(view, **)
     view.tag.ul(**group_attrs) do
       view.concat view.tag.li(name, **label_attrs)
 

--- a/app/presenters/hotwire_combobox/listbox/group.rb
+++ b/app/presenters/hotwire_combobox/listbox/group.rb
@@ -8,7 +8,7 @@ class HotwireCombobox::Listbox::Group
     @options = options
   end
 
-  def render_in(view)
+  def render_in(view, locals: nil)
     view.tag.ul(**group_attrs) do
       view.concat view.tag.li(name, **label_attrs)
 

--- a/app/presenters/hotwire_combobox/listbox/option.rb
+++ b/app/presenters/hotwire_combobox/listbox/option.rb
@@ -5,7 +5,7 @@ class HotwireCombobox::Listbox::Option
     @option = option.is_a?(Hash) ? Data.new(**option) : option
   end
 
-  def render_in(view)
+  def render_in(view, locals: nil)
     view.tag.li content, **options
   end
 

--- a/app/presenters/hotwire_combobox/listbox/option.rb
+++ b/app/presenters/hotwire_combobox/listbox/option.rb
@@ -5,7 +5,7 @@ class HotwireCombobox::Listbox::Option
     @option = option.is_a?(Hash) ? Data.new(**option) : option
   end
 
-  def render_in(view, locals: nil)
+  def render_in(view, **)
     view.tag.li content, **options
   end
 


### PR DESCRIPTION
Yo, Jose 👋 

As always, thanks for your all your hard work on Hotwire Combobox! We really appreciate it and love using it at Poll Everywhere 🧡 

Looks like Rails latest introduced a change that [introduced a deprecation warning with the #render_in signature](https://github.com/rails/rails/commit/d24d0b7187b6568d76972d61ce91eea698503797). It now passes locals and warns when the method only accepts the view context. That results in a bunch of warnings that showed up in our CI:

```
DEPRECATION WARNING: Action View support for #render_in without options is deprecated.

Change #render_in to accept keyword arguments.
 (called from block in _app_views_conditions__condition_node_html_erb__... at app/views/conditions/_condition_node.html.erb:56)
 ```

The changes simply pass `locals: nil` to ignore the new keyword Rails forward to silence the deprecation warnings. 