### PR TITLE
Fix `required` validations

### DIFF
--- a/app/assets/javascripts/controllers/hw_combobox_controller.js
+++ b/app/assets/javascripts/controllers/hw_combobox_controller.js
@@ -68,6 +68,7 @@ export default class HwComboboxController extends Concerns(...concerns) {
   idempotentConnect() {
     this._connectSelection()
     this._connectMultiselect()
+    this._connectRequired()
     this._connectListAutocomplete()
     this._connectDialog()
   }

--- a/app/assets/javascripts/hotwire_combobox.esm.js
+++ b/app/assets/javascripts/hotwire_combobox.esm.js
@@ -818,7 +818,7 @@ Combobox.FormField = Base => class extends Base {
     return !this._hasEmptyCurrentSelection
   }
 
-  get _isBlank() {
+  get _hasBlankValue() {
     return this.hiddenFieldTarget.value === ""
   }
 
@@ -1862,7 +1862,7 @@ Combobox.Toggle = Base => class extends Base {
 
 Combobox.Validity = Base => class extends Base {
   // +required+ can't live on the hidden field where the value is: hidden inputs are barred from
-  // constraint validation. Instead we toggle it on the visible +comboboxTarget+ to track +_isBlank+.
+  // constraint validation. Instead we toggle it on the visible +comboboxTarget+ to track +_hasBlankValue+.
   // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#barred-from-constraint-validation
   _connectRequired() {
     if (!("hwComboboxRequiredByAuthor" in this.comboboxTarget.dataset)) {
@@ -1875,7 +1875,7 @@ Combobox.Validity = Base => class extends Base {
   _syncRequired() {
     if (this.comboboxTarget.dataset.hwComboboxRequiredByAuthor !== "true") return
 
-    this.comboboxTarget.toggleAttribute("required", this._isBlank);
+    this.comboboxTarget.toggleAttribute("required", this._hasBlankValue);
   }
 
   _markValid() {
@@ -1911,7 +1911,7 @@ Combobox.Validity = Base => class extends Base {
   // +_valueIsInvalid+ only checks if `comboboxTarget` (and not `_actingCombobox`) is required
   // because the `required` attribute is only forwarded to the `comboboxTarget` element
   get _valueIsInvalid() {
-    const isRequiredAndEmpty = this.comboboxTarget.required && this._isBlank;
+    const isRequiredAndEmpty = this.comboboxTarget.required && this._hasBlankValue;
     return isRequiredAndEmpty
   }
 };

--- a/app/assets/javascripts/hotwire_combobox.esm.js
+++ b/app/assets/javascripts/hotwire_combobox.esm.js
@@ -802,10 +802,11 @@ Combobox.FormField = Base => class extends Base {
       this.hiddenFieldTarget.dataset.displayForMultiselect = this._fullQuery;
     } else {
       this.hiddenFieldTarget.value = value;
+      this._syncRequired();
     }
   }
 
-  get _hasEmptyFieldValue() {
+  get _hasEmptyCurrentSelection() {
     if (this._isMultiselect) {
       return this.hiddenFieldTarget.dataset.valueForMultiselect == "" || this.hiddenFieldTarget.dataset.valueForMultiselect == "undefined"
     } else {
@@ -813,8 +814,12 @@ Combobox.FormField = Base => class extends Base {
     }
   }
 
-  get _hasFieldValue() {
-    return !this._hasEmptyFieldValue
+  get _hasCurrentSelection() {
+    return !this._hasEmptyCurrentSelection
+  }
+
+  get _isBlank() {
+    return this.hiddenFieldTarget.value === ""
   }
 
   get _fieldName() {
@@ -1061,6 +1066,7 @@ Combobox.Multiselect = Base => class extends Base {
 
     newValue.add(String(value));
     this.hiddenFieldTarget.value = Array.from(newValue).join(",");
+    this._syncRequired();
 
     if (this._isSync) this._resetMultiselectionMarks();
   }
@@ -1070,6 +1076,7 @@ Combobox.Multiselect = Base => class extends Base {
 
     newValue.delete(String(value));
     this.hiddenFieldTarget.value = Array.from(newValue).join(",");
+    this._syncRequired();
 
     if (this._isSync) this._resetMultiselectionMarks();
   }
@@ -1235,7 +1242,7 @@ Combobox.Options = Base => class extends Base {
   }
 
   get _isUnjustifiablyBlank() {
-    const valueIsMissing = this._hasEmptyFieldValue;
+    const valueIsMissing = this._hasEmptyCurrentSelection;
     const noBlankOptionSelected = !this._selectedOptionElement;
 
     return valueIsMissing && noBlankOptionSelected
@@ -1260,6 +1267,7 @@ Combobox.Restoration = Base => class extends Base {
     this._fullQuery = display || "";
     this._markQueried();
     this._preselectSingle();
+    this._syncRequired();
     this._markValid();
   }
 
@@ -1274,6 +1282,7 @@ Combobox.Restoration = Base => class extends Base {
 
     if (value) this._buildChips(this._fieldValueString);
 
+    this._syncRequired();
     this._markValid();
   }
 
@@ -1409,7 +1418,7 @@ Combobox.Selection = Base => class extends Base {
   }
 
   get _hasValueButNoSelection() {
-    return this._hasFieldValue && !this._hasSelection
+    return this._hasCurrentSelection && !this._hasSelection
   }
 
   get _hasSelection() {
@@ -1852,6 +1861,23 @@ Combobox.Toggle = Base => class extends Base {
 };
 
 Combobox.Validity = Base => class extends Base {
+  // +required+ can't live on the hidden field where the value is: hidden inputs are barred from
+  // constraint validation. Instead we toggle it on the visible +comboboxTarget+ to track +_isBlank+.
+  // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#barred-from-constraint-validation
+  _connectRequired() {
+    if (!("hwComboboxRequiredByAuthor" in this.comboboxTarget.dataset)) {
+      this.comboboxTarget.dataset.hwComboboxRequiredByAuthor = this.comboboxTarget.required;
+    }
+
+    this._syncRequired();
+  }
+
+  _syncRequired() {
+    if (this.comboboxTarget.dataset.hwComboboxRequiredByAuthor !== "true") return
+
+    this.comboboxTarget.toggleAttribute("required", this._isBlank);
+  }
+
   _markValid() {
     if (this._valueIsInvalid) return
 
@@ -1885,7 +1911,7 @@ Combobox.Validity = Base => class extends Base {
   // +_valueIsInvalid+ only checks if `comboboxTarget` (and not `_actingCombobox`) is required
   // because the `required` attribute is only forwarded to the `comboboxTarget` element
   get _valueIsInvalid() {
-    const isRequiredAndEmpty = this.comboboxTarget.required && this._hasEmptyFieldValue;
+    const isRequiredAndEmpty = this.comboboxTarget.required && this._isBlank;
     return isRequiredAndEmpty
   }
 };
@@ -1955,6 +1981,7 @@ class HwComboboxController extends Concerns(...concerns) {
   idempotentConnect() {
     this._connectSelection();
     this._connectMultiselect();
+    this._connectRequired();
     this._connectListAutocomplete();
     this._connectDialog();
   }

--- a/app/assets/javascripts/hw_combobox/models/combobox/form_field.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/form_field.js
@@ -56,10 +56,11 @@ Combobox.FormField = Base => class extends Base {
       this.hiddenFieldTarget.dataset.displayForMultiselect = this._fullQuery
     } else {
       this.hiddenFieldTarget.value = value
+      this._syncRequired()
     }
   }
 
-  get _hasEmptyFieldValue() {
+  get _hasEmptyCurrentSelection() {
     if (this._isMultiselect) {
       return this.hiddenFieldTarget.dataset.valueForMultiselect == "" || this.hiddenFieldTarget.dataset.valueForMultiselect == "undefined"
     } else {
@@ -67,8 +68,12 @@ Combobox.FormField = Base => class extends Base {
     }
   }
 
-  get _hasFieldValue() {
-    return !this._hasEmptyFieldValue
+  get _hasCurrentSelection() {
+    return !this._hasEmptyCurrentSelection
+  }
+
+  get _isBlank() {
+    return this.hiddenFieldTarget.value === ""
   }
 
   get _fieldName() {

--- a/app/assets/javascripts/hw_combobox/models/combobox/form_field.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/form_field.js
@@ -72,7 +72,7 @@ Combobox.FormField = Base => class extends Base {
     return !this._hasEmptyCurrentSelection
   }
 
-  get _isBlank() {
+  get _hasBlankValue() {
     return this.hiddenFieldTarget.value === ""
   }
 

--- a/app/assets/javascripts/hw_combobox/models/combobox/multiselect.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/multiselect.js
@@ -237,6 +237,7 @@ Combobox.Multiselect = Base => class extends Base {
 
     newValue.add(String(value))
     this.hiddenFieldTarget.value = Array.from(newValue).join(",")
+    this._syncRequired()
 
     if (this._isSync) this._resetMultiselectionMarks()
   }
@@ -246,6 +247,7 @@ Combobox.Multiselect = Base => class extends Base {
 
     newValue.delete(String(value))
     this.hiddenFieldTarget.value = Array.from(newValue).join(",")
+    this._syncRequired()
 
     if (this._isSync) this._resetMultiselectionMarks()
   }

--- a/app/assets/javascripts/hw_combobox/models/combobox/options.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/options.js
@@ -52,7 +52,7 @@ Combobox.Options = Base => class extends Base {
   }
 
   get _isUnjustifiablyBlank() {
-    const valueIsMissing = this._hasEmptyFieldValue
+    const valueIsMissing = this._hasEmptyCurrentSelection
     const noBlankOptionSelected = !this._selectedOptionElement
 
     return valueIsMissing && noBlankOptionSelected

--- a/app/assets/javascripts/hw_combobox/models/combobox/restoration.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/restoration.js
@@ -18,6 +18,7 @@ Combobox.Restoration = Base => class extends Base {
     this._fullQuery = display || ""
     this._markQueried()
     this._preselectSingle()
+    this._syncRequired()
     this._markValid()
   }
 
@@ -32,6 +33,7 @@ Combobox.Restoration = Base => class extends Base {
 
     if (value) this._buildChips(this._fieldValueString)
 
+    this._syncRequired()
     this._markValid()
   }
 

--- a/app/assets/javascripts/hw_combobox/models/combobox/selection.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/selection.js
@@ -135,7 +135,7 @@ Combobox.Selection = Base => class extends Base {
   }
 
   get _hasValueButNoSelection() {
-    return this._hasFieldValue && !this._hasSelection
+    return this._hasCurrentSelection && !this._hasSelection
   }
 
   get _hasSelection() {

--- a/app/assets/javascripts/hw_combobox/models/combobox/validity.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/validity.js
@@ -2,7 +2,7 @@ import Combobox from "hw_combobox/models/combobox/base"
 
 Combobox.Validity = Base => class extends Base {
   // +required+ can't live on the hidden field where the value is: hidden inputs are barred from
-  // constraint validation. Instead we toggle it on the visible +comboboxTarget+ to track +_isBlank+.
+  // constraint validation. Instead we toggle it on the visible +comboboxTarget+ to track +_hasBlankValue+.
   // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#barred-from-constraint-validation
   _connectRequired() {
     if (!("hwComboboxRequiredByAuthor" in this.comboboxTarget.dataset)) {
@@ -15,7 +15,7 @@ Combobox.Validity = Base => class extends Base {
   _syncRequired() {
     if (this.comboboxTarget.dataset.hwComboboxRequiredByAuthor !== "true") return
 
-    this.comboboxTarget.toggleAttribute("required", this._isBlank)
+    this.comboboxTarget.toggleAttribute("required", this._hasBlankValue)
   }
 
   _markValid() {
@@ -51,7 +51,7 @@ Combobox.Validity = Base => class extends Base {
   // +_valueIsInvalid+ only checks if `comboboxTarget` (and not `_actingCombobox`) is required
   // because the `required` attribute is only forwarded to the `comboboxTarget` element
   get _valueIsInvalid() {
-    const isRequiredAndEmpty = this.comboboxTarget.required && this._isBlank
+    const isRequiredAndEmpty = this.comboboxTarget.required && this._hasBlankValue
     return isRequiredAndEmpty
   }
 }

--- a/app/assets/javascripts/hw_combobox/models/combobox/validity.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/validity.js
@@ -1,6 +1,23 @@
 import Combobox from "hw_combobox/models/combobox/base"
 
 Combobox.Validity = Base => class extends Base {
+  // +required+ can't live on the hidden field where the value is: hidden inputs are barred from
+  // constraint validation. Instead we toggle it on the visible +comboboxTarget+ to track +_isBlank+.
+  // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#barred-from-constraint-validation
+  _connectRequired() {
+    if (!("hwComboboxRequiredByAuthor" in this.comboboxTarget.dataset)) {
+      this.comboboxTarget.dataset.hwComboboxRequiredByAuthor = this.comboboxTarget.required
+    }
+
+    this._syncRequired()
+  }
+
+  _syncRequired() {
+    if (this.comboboxTarget.dataset.hwComboboxRequiredByAuthor !== "true") return
+
+    this.comboboxTarget.toggleAttribute("required", this._isBlank)
+  }
+
   _markValid() {
     if (this._valueIsInvalid) return
 
@@ -34,7 +51,7 @@ Combobox.Validity = Base => class extends Base {
   // +_valueIsInvalid+ only checks if `comboboxTarget` (and not `_actingCombobox`) is required
   // because the `required` attribute is only forwarded to the `comboboxTarget` element
   get _valueIsInvalid() {
-    const isRequiredAndEmpty = this.comboboxTarget.required && this._hasEmptyFieldValue
+    const isRequiredAndEmpty = this.comboboxTarget.required && this._isBlank
     return isRequiredAndEmpty
   }
 }

--- a/test/dummy/app/controllers/comboboxes_controller.rb
+++ b/test/dummy/app/controllers/comboboxes_controller.rb
@@ -19,6 +19,9 @@ class ComboboxesController < ApplicationController
   def required
   end
 
+  def single_select_required
+  end
+
   def restoration
     @movie = Movie.first || raise("No movie found, load fixtures first.")
     @restorable_states = State.where(name: %w[ Florida Illinois ]).order(:name)
@@ -105,6 +108,9 @@ class ComboboxesController < ApplicationController
 
   def multiselect_prefilled_form
     @user = User.first || raise("No user found, load fixtures first.")
+  end
+
+  def multiselect_required
   end
 
   def multiselect_custom_events

--- a/test/dummy/app/views/comboboxes/multiselect_required.html.erb
+++ b/test/dummy/app/views/comboboxes/multiselect_required.html.erb
@@ -1,0 +1,14 @@
+<%= combobox_tag "prefilled_state", State.all,
+      id: "prefilled-required-field",
+      label: "Prefilled states",
+      multiselect_chip_src: state_chips_path,
+      value: State.where(name: %w[ Alabama ]).pluck(:id).join(","),
+      required: true,
+      placeholder: "Select states" %>
+
+<%= combobox_tag "empty_state", State.all,
+      id: "empty-required-field",
+      label: "Empty states",
+      multiselect_chip_src: state_chips_path,
+      required: true,
+      placeholder: "Select states" %>

--- a/test/dummy/app/views/comboboxes/single_select_required.html.erb
+++ b/test/dummy/app/views/comboboxes/single_select_required.html.erb
@@ -1,0 +1,2 @@
+<%= combobox_tag "state", @state_options, value: "MI", id: "prefilled-required-single", required: true %>
+<%= combobox_tag "state2", @state_options, id: "empty-required-single", required: true %>

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -28,6 +28,7 @@ Rails.application.routes.draw do
   get "multiselect_custom_events", to: "comboboxes#multiselect_custom_events"
   get "multiselect_new_values", to: "comboboxes#multiselect_new_values"
   get "multiselect_prefilled_form", to: "comboboxes#multiselect_prefilled_form"
+  get "multiselect_required", to: "comboboxes#multiselect_required"
   get "new_options", to: "comboboxes#new_options"
   get "open", to: "comboboxes#open"
   get "padded", to: "comboboxes#padded"
@@ -40,6 +41,7 @@ Rails.application.routes.draw do
   get "render_in", to: "comboboxes#render_in"
   get "render_in_locals", to: "comboboxes#render_in_locals"
   get "required", to: "comboboxes#required"
+  get "single_select_required", to: "comboboxes#single_select_required"
   get "restoration", to: "comboboxes#restoration"
   get "turbo_streamed_block", to: "comboboxes#turbo_streamed_block"
 

--- a/test/system/validity_test.rb
+++ b/test/system/validity_test.rb
@@ -21,4 +21,36 @@ class ValidityTest < ApplicationSystemTestCase
     type_in_combobox "#state-field", "Flor", :backspace, :enter
     assert_not_invalid_combobox
   end
+
+  test "required single select reflects the selected value, not the search input" do
+    visit single_select_required_path
+
+    assert_selector "input#empty-required-single[required]"
+    assert_selector "input#prefilled-required-single:not([required])"
+
+    open_combobox "#empty-required-single"
+    click_on_option "Alabama"
+    assert_selector "input#empty-required-single:not([required])"
+  end
+
+  test "required multiselect drops native required once it has chips" do
+    visit multiselect_required_path
+
+    assert_selector "input#empty-required-field[required]"
+    assert_selector "input#prefilled-required-field:not([required])"
+
+    open_combobox "#empty-required-field"
+    click_on_option "Alabama"
+    assert_chip_with text: "Alabama"
+    assert_selector "input#empty-required-field:not([required])"
+  end
+
+  test "required multiselect restores native required when it loses all chips" do
+    visit multiselect_required_path
+
+    assert_selector "input#prefilled-required-field:not([required])"
+
+    remove_chip "Alabama"
+    assert_selector "input#prefilled-required-field[required]"
+  end
 end

--- a/test/system/validity_test.rb
+++ b/test/system/validity_test.rb
@@ -33,6 +33,14 @@ class ValidityTest < ApplicationSystemTestCase
     assert_selector "input#empty-required-single:not([required])"
   end
 
+  test "required single select stays required when the search input has no matching selection" do
+    visit single_select_required_path
+
+    type_in_combobox "#empty-required-single", "foobar"
+    assert_invalid_combobox
+    assert_selector "input#empty-required-single[required]"
+  end
+
   test "required multiselect drops native required once it has chips" do
     visit multiselect_required_path
 


### PR DESCRIPTION
They only worked on single-selects incidentally because the input and value were tied (they both had a value when not blank).

This is not the case in multiselects, which can have a value with a blank input after selecting a chip, or when prefilled.