### PR TITLE
Tighten up clearing a combobox

### DIFF
--- a/app/assets/javascripts/hotwire_combobox.esm.js
+++ b/app/assets/javascripts/hotwire_combobox.esm.js
@@ -258,6 +258,11 @@ Combobox.Callbacks = Base => class extends Base {
     this._forgetCallbackExecutionAttempts(callbackId);
   }
 
+  _flushCallbackQueue() {
+    this.callbackQueue = [];
+    this.callbackExecutionAttempts = {};
+  }
+
   _forgetCallbackExecutionAttempts(callbackId) {
     delete this.callbackExecutionAttempts[callbackId];
   }
@@ -722,7 +727,9 @@ Combobox.Filtering = Base => class extends Base {
 
   _clearQuery() {
     this._fullQuery = "";
-    this.filterAndSelect({ inputType: "deleteContentBackward" });
+    this._flushCallbackQueue();
+    this._resetOptionsAndNotify();
+    this._filter("deleteContentBackward");
   }
 
   _markQueried() {

--- a/app/assets/javascripts/hw_combobox/models/combobox/callbacks.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/callbacks.js
@@ -36,6 +36,11 @@ Combobox.Callbacks = Base => class extends Base {
     this._forgetCallbackExecutionAttempts(callbackId)
   }
 
+  _flushCallbackQueue() {
+    this.callbackQueue = []
+    this.callbackExecutionAttempts = {}
+  }
+
   _forgetCallbackExecutionAttempts(callbackId) {
     delete this.callbackExecutionAttempts[callbackId]
   }

--- a/app/assets/javascripts/hw_combobox/models/combobox/filtering.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/filtering.js
@@ -64,7 +64,9 @@ Combobox.Filtering = Base => class extends Base {
 
   _clearQuery() {
     this._fullQuery = ""
-    this.filterAndSelect({ inputType: "deleteContentBackward" })
+    this._flushCallbackQueue()
+    this._resetOptionsAndNotify()
+    this._filter("deleteContentBackward")
   }
 
   _markQueried() {

--- a/test/system/custom_events_test.rb
+++ b/test/system/custom_events_test.rb
@@ -166,6 +166,28 @@ class CustomEventsTest < ApplicationSystemTestCase
     end
   end
 
+  test "clearing reverts a brand-new value's field name back to the original" do
+    visit custom_events_path
+
+    open_combobox "#allow-new"
+    type_in_combobox "#allow-new", "A Beat"
+
+    within "#preselection" do
+      assert_text "fieldName: new_movie"
+    end
+
+    within selector_root("#allow-new") do
+      find(".hw-combobox__handle").click
+    end
+
+    within "#preselection" do
+      assert_text "event: hw-combobox:preselection"
+      assert_text "value: <empty>"
+      assert_text "fieldName: movie"
+      assert_text "previousValue: A Beat"
+    end
+  end
+
   private
     def selector_root(selector)
       "fieldset[data-controller~='hw-combobox']:has(#{selector})"


### PR DESCRIPTION
A couple of wins here. After this change:

1. The submitted value is correct synchronously. Before, async clear() didn't empty the hidden field until the round-trip landed on async comboboxes
2. Clearing a free-text value now reverts the field name to the original
3. Clearing no longer depends on a network call succeeding on async comboboxes.
4. No re-selection race on async comboboxes. The queue flush means an in-flight response for the prior query can't land after a clear and re-select something
5. There's a reliable, synchronous "cleared" event on async comboboxes