### PR TITLE
Make the selection event congruent with preselection (isNewAndAllowed, previousValue, fire-on-change)

### DIFF
--- a/app/assets/javascripts/hotwire_combobox.esm.js
+++ b/app/assets/javascripts/hotwire_combobox.esm.js
@@ -342,9 +342,15 @@ Combobox.Events = Base => class extends Base {
   }
 
   _dispatchSelectionEvent() {
+    const previousValue = this._previousSelectionValue;
+
+    if (previousValue === this._incomingFieldValueString) return
+
+    this._previousSelectionValue = this._incomingFieldValueString;
+
     dispatch("hw-combobox:selection", {
       target: this.element,
-      detail: this._eventableDetails
+      detail: { ...this._eventableDetails, previousValue }
     });
   }
 
@@ -1307,6 +1313,8 @@ Combobox.Selection = Base => class extends Base {
   }
 
   _connectSelection() {
+    this._previousSelectionValue = this._incomingFieldValueString;
+
     if (this.hasPrefilledDisplayValue) {
       this._fullQuery = this.prefilledDisplayValue;
       this._markQueried();

--- a/app/assets/javascripts/hotwire_combobox.esm.js
+++ b/app/assets/javascripts/hotwire_combobox.esm.js
@@ -369,6 +369,7 @@ Combobox.Events = Base => class extends Base {
       query: this._typedQuery,
       fieldName: this._fieldName,
       originalName: this.originalNameValue,
+      isNewAndAllowed: this._isNewOptionWithPotentialMatches,
       isValid: this._valueIsValid,
       chipData: this._currentChipData
     }

--- a/app/assets/javascripts/hw_combobox/models/combobox/events.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/events.js
@@ -39,6 +39,7 @@ Combobox.Events = Base => class extends Base {
       query: this._typedQuery,
       fieldName: this._fieldName,
       originalName: this.originalNameValue,
+      isNewAndAllowed: this._isNewOptionWithPotentialMatches,
       isValid: this._valueIsValid,
       chipData: this._currentChipData
     }

--- a/app/assets/javascripts/hw_combobox/models/combobox/events.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/events.js
@@ -12,9 +12,15 @@ Combobox.Events = Base => class extends Base {
   }
 
   _dispatchSelectionEvent() {
+    const previousValue = this._previousSelectionValue
+
+    if (previousValue === this._incomingFieldValueString) return
+
+    this._previousSelectionValue = this._incomingFieldValueString
+
     dispatch("hw-combobox:selection", {
       target: this.element,
-      detail: this._eventableDetails
+      detail: { ...this._eventableDetails, previousValue }
     })
   }
 

--- a/app/assets/javascripts/hw_combobox/models/combobox/selection.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/selection.js
@@ -9,6 +9,8 @@ Combobox.Selection = Base => class extends Base {
   }
 
   _connectSelection() {
+    this._previousSelectionValue = this._incomingFieldValueString
+
     if (this.hasPrefilledDisplayValue) {
       this._fullQuery = this.prefilledDisplayValue
       this._markQueried()

--- a/test/system/custom_events_test.rb
+++ b/test/system/custom_events_test.rb
@@ -50,7 +50,7 @@ class CustomEventsTest < ApplicationSystemTestCase
       assert_text "display: A Beat"
       assert_text "query: A Beat"
       assert_text "fieldName: new_movie"
-      assert_text "isNewAndAllowed: <empty>"
+      assert_text "isNewAndAllowed: true"
       assert_text "isValid: true"
     end
 
@@ -92,7 +92,7 @@ class CustomEventsTest < ApplicationSystemTestCase
       assert_text "display: <empty>"
       assert_text "query: <empty>"
       assert_text "fieldName: movie"
-      assert_text "isNewAndAllowed: <empty>"
+      assert_text "isNewAndAllowed: false"
       assert_text "isValid: false"
     end
 
@@ -105,6 +105,13 @@ class CustomEventsTest < ApplicationSystemTestCase
     within "#preselection" do
       assert_text "previousValue: #{movies(:the_godfather_part_ii).id}"
     end
+
+    within "#selection" do
+      assert_text "event: hw-combobox:selection"
+      assert_text "value: #{movies(:the_godfather_part_iii).id}"
+      assert_text "isNewAndAllowed: false"
+    end
+
     assert_text "preselections: 6."
     assert_text "selections: 4."
   end

--- a/test/system/custom_events_test.rb
+++ b/test/system/custom_events_test.rb
@@ -52,6 +52,7 @@ class CustomEventsTest < ApplicationSystemTestCase
       assert_text "fieldName: new_movie"
       assert_text "isNewAndAllowed: true"
       assert_text "isValid: true"
+      assert_text "previousValue: <empty>"
     end
 
     open_combobox "#required"
@@ -85,15 +86,11 @@ class CustomEventsTest < ApplicationSystemTestCase
 
     click_away
 
-    assert_text "selections: 2."
+    # The committed value never changed (empty in, empty out), so no selection
+    # fires — the previous selection ("A Beat") still stands.
+    assert_text "selections: 1."
     within "#selection" do
-      assert_text "event: hw-combobox:selection"
-      assert_text "value: <empty>"
-      assert_text "display: <empty>"
-      assert_text "query: <empty>"
-      assert_text "fieldName: movie"
-      assert_text "isNewAndAllowed: false"
-      assert_text "isValid: false"
+      assert_text "value: A Beat"
     end
 
     open_combobox "#required"
@@ -110,10 +107,29 @@ class CustomEventsTest < ApplicationSystemTestCase
       assert_text "event: hw-combobox:selection"
       assert_text "value: #{movies(:the_godfather_part_iii).id}"
       assert_text "isNewAndAllowed: false"
+      assert_text "previousValue: #{movies(:the_godfather_part_ii).id}"
     end
 
     assert_text "preselections: 6."
-    assert_text "selections: 4."
+    assert_text "selections: 3."
+  end
+
+  test "reopening and closing without changing the value does not fire a selection" do
+    visit custom_events_path
+
+    open_combobox "#required"
+    type_in_combobox "#required", "The Godfather"
+    click_on_option "The Godfather Part II"
+    assert_text "selections: 1."
+
+    open_combobox "#required"
+    click_away
+    assert_text "selections: 1."
+
+    within "#selection" do
+      assert_text "value: #{movies(:the_godfather_part_ii).id}"
+      assert_text "previousValue: <empty>"
+    end
   end
 
   test "preselection and selection events include chipData from option data-chip-* attrs" do

--- a/test/system/multiselect_test.rb
+++ b/test/system/multiselect_test.rb
@@ -229,7 +229,7 @@ class MultiselectTest < ApplicationSystemTestCase
       assert_text "fieldName: states."
       assert_text "isNewAndAllowed: false."
       assert_text "isValid: true."
-      assert_text "previousValue: <empty>."
+      assert_text "previousValue: #{states(:arkansas).id}."
       assert_text "removedDisplay: <empty>."
       assert_text "removedValue: <empty>."
     end

--- a/test/system/multiselect_test.rb
+++ b/test/system/multiselect_test.rb
@@ -190,7 +190,7 @@ class MultiselectTest < ApplicationSystemTestCase
       assert_text "display: Michigan"
       assert_text "query: Mi."
       assert_text "fieldName: states"
-      assert_text "isNewAndAllowed: <empty>"
+      assert_text "isNewAndAllowed: false"
       assert_text "isValid: true"
       assert_text "previousValue: <empty>"
     end
@@ -227,7 +227,7 @@ class MultiselectTest < ApplicationSystemTestCase
       assert_text "display: Colorado."
       assert_text "query: <empty>."
       assert_text "fieldName: states."
-      assert_text "isNewAndAllowed: <empty>."
+      assert_text "isNewAndAllowed: false."
       assert_text "isValid: true."
       assert_text "previousValue: <empty>."
       assert_text "removedDisplay: <empty>."


### PR DESCRIPTION
Makes `hw-combobox:selection` congruent with `hw-combobox:preselection`. Consumers naturally wire both events to one handler, but `selection` was the odd one out: it omitted `isNewAndAllowed` and `previousValue`, and it fired on *every* close. Each of those is a quiet footgun; this PR closes all three.

### 1. Report `isNewAndAllowed` on `selection` (and `removal`/`restoration`)

`selection` built its `detail` straight from `_eventableDetails`, which omitted `isNewAndAllowed` — only `preselection` added it explicitly. Because it's *absent* (not `false`), the idiomatic `detail.isNewAndAllowed ? … : …` silently takes the picked-option branch for a committed free-text value.

Derived once on `_eventableDetails` via `_isNewOptionWithPotentialMatches` — the same "locked-in on close" check documented in `new_options.js`:

```diff
   get _eventableDetails() {
     return {
       ...
+      isNewAndAllowed: this._isNewOptionWithPotentialMatches,
       isValid: this._valueIsValid,
       chipData: this._currentChipData
     }
   }
```

Additive and backward compatible: `preselection`'s explicit value still wins via spread order (unchanged), and the derived getter agrees with all three explicit call sites (`_select`→false, `_selectNew`→true, `_deselectAndNotify`→false).

### 2. Only fire `selection` on an actual change

`selection` fired on every `close()` — a pure open/close, or an invalid attempt cleared back to the starting value, both emitted it — conflating "the listbox closed" with "a value was selected." A handler that mirrors the value elsewhere then re-applies a stale value on an incidental blur.

Now it's gated on a real change: the committed value is snapshotted on connect and after each selection, and the event is skipped when it hasn't changed since. This mirrors the guard `preselection` already has (`if (previousValue === this._incomingFieldValueString) return`).

> ⚠️ Behavior change: consumers that relied on `selection` as a "combobox closed" signal regardless of change will now only hear it on change. That's the intended semantics (the event name is "selection", not "close"), but calling it out.

### 3. Add `previousValue` to `selection`

The snapshot the gate compares against *is* the event's `previousValue`, so it's now in the detail — matching `preselection`. The two events are now symmetric: both fire only on change and both report `previousValue`.

## Tests

- Updated the `selection` assertions in `custom_events_test.rb` / `multiselect_test.rb` that documented the old gaps (`isNewAndAllowed: <empty>` → real values; added `previousValue`; the invalid-close no longer fires, so its count/scratchpad assertions were adjusted).
- Added `test "reopening and closing without changing the value does not fire a selection"`.

Full suite green locally: `bin/test` (45 runs) and `bin/test_system` (96 runs, 801 assertions), 0 failures.

> Docs note: the events reference on hotwirecombobox.com could now document `isNewAndAllowed` + `previousValue` on `selection`, and that it fires on change (not on every close) — nothing in-repo to change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
