### PR TITLE
Stop hiding chips for the Turbo cache

### DIFF
--- a/app/assets/javascripts/hotwire_combobox.esm.js
+++ b/app/assets/javascripts/hotwire_combobox.esm.js
@@ -871,10 +871,6 @@ Combobox.Multiselect = Base => class extends Base {
     this._dispatchRemovalEvent({ removedDisplay: display, removedValue: params.value });
   }
 
-  hideChipsForCache() {
-    this.element.querySelectorAll("[data-hw-combobox-chip]").forEach(chip => chip.hidden = true);
-  }
-
   _chipKeyHandlers = {
     Backspace: (event) => {
       this.removeChip(event);

--- a/app/assets/javascripts/hw_combobox/models/combobox/multiselect.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/multiselect.js
@@ -35,10 +35,6 @@ Combobox.Multiselect = Base => class extends Base {
     this._dispatchRemovalEvent({ removedDisplay: display, removedValue: params.value })
   }
 
-  hideChipsForCache() {
-    this.element.querySelectorAll("[data-hw-combobox-chip]").forEach(chip => chip.hidden = true)
-  }
-
   _chipKeyHandlers = {
     Backspace: (event) => {
       this.removeChip(event)

--- a/app/presenters/hotwire_combobox/component/markup/input.rb
+++ b/app/presenters/hotwire_combobox/component/markup/input.rb
@@ -26,7 +26,6 @@ module HotwireCombobox::Component::Markup::Input
         click@window->hw-combobox#closeOnClickOutside
         focusin@window->hw-combobox#closeOnFocusOutside
         turbo:before-stream-render@document->hw-combobox#rerouteListboxStreamToDialog
-        turbo:before-cache@document->hw-combobox#hideChipsForCache
         turbo:morph-element->hw-combobox#idempotentConnect
       ].append(data.delete(:action)).compact.join(" ")
 


### PR DESCRIPTION
### The bug

A multiselect combobox loses its chips — permanently — when it sits outside a Turbo frame it navigates.

Repro: a filter form containing the combobox, targeting a results frame with `data-turbo-action="advance"` so the URL stays shareable. Pick an option, submit. The frame updates and the chip vanishes. It's still in the DOM, just `hidden`, and nothing ever shows it again.

### Why

`hideChipsForCache` hides every chip on `turbo:before-cache`. That's safe only because a full-page visit replaces the document immediately after, discarding the hidden chips along with it.

`turbo-action` on a frame breaks the assumption. The event sequence is:

```
turbo:frame-render → turbo:visit → turbo:before-cache → turbo:load
```

A visit fires, so the page gets cached — but the document is never replaced. The combobox lives outside the frame, so nothing re-renders it, and the chips stay hidden. `turbo-action="replace"` behaves identically; only the history entry differs.

### The fix

Remove it. `hideChipsForCache` landed in 6bbceeb ("Fix chips flicker") alongside the `data-multi-preselected` guard, and the guard already covers what the hiding was there for.

On connect the controller reads the hidden field's value and creates a chip element for each one — either by cloning `chip_template` locally, or by POSTing to `multiselect_chip_src` and appending the response. A page rendered from Turbo's cache already contains last time's chip elements, and it also carries `data-multi-preselected`, which the controller wrote on its first connect. The guard sees that attribute and skips creating chips at all, so a second set never lands on top of the ones already in the HTML.

What the hiding added on top of that was a preference between two equally wrong previews: an empty combobox rather than one showing outdated chips. Not worth a mutated live DOM.

Dropping it means a restoration visit now shows the cached chips instead of suppressing them, which reflects the state you left the page in.

### Notes

No test. The behaviour that changes is preview rendering, which isn't practical to drive deterministically, and a test on the frame-navigation case would only guard against re-adding code that shouldn't have existed. Full suite green: 95 system runs / 797 assertions, 45 unit runs / 268 assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)