### PR TITLE
Guard against keydown events without a key

### DIFF
--- a/app/assets/javascripts/hotwire_combobox.esm.js
+++ b/app/assets/javascripts/hotwire_combobox.esm.js
@@ -677,7 +677,8 @@ async function post(url, options) {
 
 Combobox.Filtering = Base => class extends Base {
   prepareToFilter({ key }) {
-    const intendsToFilter = key.match(/^[a-zA-Z0-9]$|^ArrowDown$/);
+    // Some soft keyboards and autofill overlays emit keydown events without a `key`.
+    const intendsToFilter = key?.match(/^[a-zA-Z0-9]$|^ArrowDown$/);
 
     if (this._isClosed && intendsToFilter) {
       this.open(); // `.open()` sets the appropriate state so the combobox knows it’s open.

--- a/app/assets/javascripts/hw_combobox/models/combobox/filtering.js
+++ b/app/assets/javascripts/hw_combobox/models/combobox/filtering.js
@@ -5,7 +5,8 @@ import { get } from "hw_combobox/vendor/requestjs"
 
 Combobox.Filtering = Base => class extends Base {
   prepareToFilter({ key }) {
-    const intendsToFilter = key.match(/^[a-zA-Z0-9]$|^ArrowDown$/)
+    // Some soft keyboards and autofill overlays emit keydown events without a `key`.
+    const intendsToFilter = key?.match(/^[a-zA-Z0-9]$|^ArrowDown$/)
 
     if (this._isClosed && intendsToFilter) {
       this.open() // `.open()` sets the appropriate state so the combobox knows it’s open.

--- a/test/lib/helpers/combobox_actions_helper.rb
+++ b/test/lib/helpers/combobox_actions_helper.rb
@@ -7,6 +7,25 @@ module ComboboxActionsHelper
     find(selector).send_keys(*text)
   end
 
+  # Simulates the keydown events some soft keyboards and autofill overlays emit,
+  # which carry no `key` at all.
+  def type_unidentifiable_key_in_combobox(selector)
+    page.execute_script <<~JS, find(selector)
+      arguments[0].dispatchEvent(new Event("keydown", { bubbles: true }))
+    JS
+  end
+
+  def recording_stimulus_errors
+    page.execute_script <<~JS
+      window.recordedStimulusErrors = []
+      window.Stimulus.handleError = error => window.recordedStimulusErrors.push(error.message)
+    JS
+
+    yield
+
+    page.evaluate_script "window.recordedStimulusErrors"
+  end
+
   def delete_from_combobox(selector, text, original:)
     find(selector).then do |input|
       original.chars.each { input.send_keys(:arrow_right) }

--- a/test/system/keyboard_navigation_test.rb
+++ b/test/system/keyboard_navigation_test.rb
@@ -140,4 +140,22 @@ class KeyboardNavigationTest < ApplicationSystemTestCase
     assert_combobox_display_and_value "#state-field", "Michigan", "MI"
     assert_selected_option_with text: "Michigan"
   end
+
+  test "a keydown without a key leaves a closed listbox alone" do
+    visit html_options_path
+
+    open_combobox "#state-field"
+    type_in_combobox "#state-field", :escape
+    assert_closed_combobox
+
+    errors = recording_stimulus_errors do
+      type_unidentifiable_key_in_combobox "#state-field"
+    end
+
+    assert_empty errors
+    assert_closed_combobox
+
+    send_keys "m"
+    assert_open_combobox
+  end
 end


### PR DESCRIPTION
`prepareToFilter` destructures `key` off the keydown event and calls `.match` on it unconditionally. Not every keydown carries a `key`: Android soft keyboards and autofill overlays emit keydown events with no `key` at all, which throws

    TypeError: Cannot read properties of undefined (reading 'match')

out of `keydown->hw-combobox#prepareToFilter`. Stimulus catches it, so the combobox keeps working, but a closed listbox misses its chance to open on that keystroke, and the error is noisy in error trackers.

`navigate` and `navigateChip` already guard their `event.key` lookups with `?.`, so this brings `prepareToFilter` in line with them.